### PR TITLE
Fixed bugs in InsertPTS

### DIFF
--- a/packet/create.go
+++ b/packet/create.go
@@ -24,6 +24,8 @@ SOFTWARE.
 
 package packet
 
+import "github.com/Comcast/gots/pes"
+
 var (
 	required = []func(*Packet){setSyncByte}
 )
@@ -186,18 +188,9 @@ func WithPES(pkt *Packet, pts uint64) {
 	pay[7] = 0x80
 	// Header len
 	pay[8] = 14
-	InsertPTS(pay[9:14], pts)
+	pes.InsertPTS(pay[9:14], pts)
 	SetPayload(pkt, pay)
 	WithHasPayloadFlag(pkt)
-}
-
-// InsertPTS insterts a given pts time into a byte slice
-func InsertPTS(b []byte, pts uint64) {
-	b[0] = byte(pts >> 29 & 0x07)
-	b[1] = byte(pts >> 22 & 0x4f)
-	b[2] = byte(pts >> 14 & 0xff)
-	b[3] = byte(pts >> 7 & 0x7f)
-	b[4] = byte(pts&0xff) << 1
 }
 
 // SetPayload sets the payload of a given packet

--- a/pes/pesheader.go
+++ b/pes/pesheader.go
@@ -105,17 +105,6 @@ type pESHeader struct {
 	data                  []byte
 }
 
-// ExtractTime extracts a PTS time
-func ExtractTime(bytes []byte) uint64 {
-	var a, b, c, d, e uint64
-	a = uint64((bytes[0] >> 1) & 0x07)
-	b = uint64(bytes[1])
-	c = uint64((bytes[2] >> 1) & 0x7f)
-	d = uint64(bytes[3])
-	e = uint64((bytes[4] >> 1) & 0x7f)
-	return (a << 30) | (b << 22) | (c << 15) | (d << 7) | e
-}
-
 // NewPESHeader creates a new PES header with the provided bytes.
 // pesBytes is the packet payload that contains the PES data
 func NewPESHeader(pesBytes []byte) (PESHeader, error) {

--- a/pes/pts.go
+++ b/pes/pts.go
@@ -88,3 +88,29 @@ func (p PTS) Add(x PTS) PTS {
 	}
 	return PTS(result)
 }
+
+// ExtractTime extracts a PTS time
+func ExtractTime(bytes []byte) uint64 {
+	var a, b, c, d, e uint64
+	a = uint64((bytes[0] >> 1) & 0x07)
+	b = uint64(bytes[1])
+	c = uint64((bytes[2] >> 1) & 0x7f)
+	d = uint64(bytes[3])
+	e = uint64((bytes[4] >> 1) & 0x7f)
+	return (a << 30) | (b << 22) | (c << 15) | (d << 7) | e
+}
+
+// InsertPTS insterts a given pts time into a byte slice and sets the
+// marker bits.  len(b) >= 5
+func InsertPTS(b []byte, pts uint64) {
+	b[0] = byte(pts >> 29 & 0x0f) // PTS[32..30]
+	b[1] = byte(pts >> 22 & 0xff) // PTS[29..22]
+	b[2] = byte(pts >> 14 & 0xff) // PTS[21..15]
+	b[3] = byte(pts >> 7 & 0xff)  // PTS[14..8]
+	b[4] = byte(pts&0xff) << 1    // PTS[7..0]
+
+	// Set the marker bits as appropriate
+	b[0] |= 0x21
+	b[2] |= 0x01
+	b[4] |= 0x01
+}

--- a/pes/pts_test.go
+++ b/pes/pts_test.go
@@ -117,3 +117,13 @@ func TestAdd(t *testing.T) {
 		t.Error("PTS addition 2 test failed")
 	}
 }
+
+func TestInsertPTS(t *testing.T) {
+	var pts uint64 = 0x1DEADBEEF
+	b := make([]byte, 5)
+	InsertPTS(b, pts)
+	if ExtractTime(b) != 0x1DEADBEEF {
+		t.Error("Insert PTS test 1 failed")
+	}
+
+}


### PR DESCRIPTION
 -InsertPTS now correctly sets PTS time
 -InsertPTS now correctly sets markers as defined in spec
 -Added test case
 -Moved ExtractTime and InsertPTS into pts.go for better organization