### PR TITLE
Fixes to PTS and organization of pts.go

### DIFF
--- a/packet/create.go
+++ b/packet/create.go
@@ -24,6 +24,8 @@ SOFTWARE.
 
 package packet
 
+import "github.com/comcast/gots"
+
 var (
 	required = []func(*Packet){setSyncByte}
 )
@@ -186,7 +188,7 @@ func WithPES(pkt *Packet, pts uint64) {
 	pay[7] = 0x80
 	// Header len
 	pay[8] = 14
-	InsertPTS(pay[9:14], pts)
+	mpegts.InsertPTS(pay[9:14], pts)
 	SetPayload(pkt, pay)
 	WithHasPayloadFlag(pkt)
 }

--- a/pes/doc.go
+++ b/pes/doc.go
@@ -25,8 +25,6 @@ SOFTWARE.
 // Package pes contains interfaces and operations for packetized elementary stream headers.
 package pes
 
-import "math"
-
 // stream_id possibilities
 const (
 	STREAM_ID_ALL_AUDIO_STREAMS           uint8 = 184
@@ -53,19 +51,6 @@ const (
 	STREAM_ID_PROGRAM_STREAM_DIRECTORY          = 255
 )
 
-// PTS constants
-const (
-	PTS_DTS_INDICATOR_BOTH     = 3 // 11
-	PTS_DTS_INDICATOR_ONLY_PTS = 2 // 10
-	PTS_DTS_INDICATOR_NONE     = 0 // 00
-	// PTS_MAX is the highest value the PTS can hold before it rolls over, since its a 33 bit timestamp.
-	PTS_MAX = 8589934591 // 2^33 - 1
-	// Used as a sentinel values for algorithms working against PTS
-	PtsNegativeInfinity = PTS(math.MaxUint64 - 1)
-	PtsPositiveInfinity = PTS(math.MaxUint64)
-	PtsClockRate        = 90000
-)
-
 // PESHeader represents operations available on a packetized elementary stream header.
 type PESHeader interface {
 	// HasPTS returns true if the header has a PTS time
@@ -81,6 +66,3 @@ type PESHeader interface {
 	// PacketStartCodePrefix returns the packet_start_code_prefix. Note that this is a 24 bit value.
 	PacketStartCodePrefix() uint32
 }
-
-// PTS represents PTS time
-type PTS uint64

--- a/pes/pesheader.go
+++ b/pes/pesheader.go
@@ -27,6 +27,8 @@ package pes
 import (
 	"errors"
 	"fmt"
+
+	"github.com/comcast/gots"
 )
 
 /*
@@ -141,16 +143,16 @@ func NewPESHeader(pesBytes []byte) (PESHeader, error) {
 
 			pes.ptsDtsIndicator = ptsDtsIndicator
 
-			if (ptsDtsIndicator == PTS_DTS_INDICATOR_BOTH ||
-				ptsDtsIndicator == PTS_DTS_INDICATOR_ONLY_PTS) &&
+			if (ptsDtsIndicator == mpegts.PTS_DTS_INDICATOR_BOTH ||
+				ptsDtsIndicator == mpegts.PTS_DTS_INDICATOR_ONLY_PTS) &&
 				CheckLength(pesBytes, "PTS", 14) {
 
-				pes.pts = ExtractTime(pesBytes[9:14])
+				pes.pts = mpegts.ExtractTime(pesBytes[9:14])
 
-				if pes.ptsDtsIndicator == PTS_DTS_INDICATOR_BOTH &&
+				if pes.ptsDtsIndicator == mpegts.PTS_DTS_INDICATOR_BOTH &&
 					CheckLength(pesBytes, "DTS", 19) {
 
-					pes.dts = ExtractTime(pesBytes[14:19])
+					pes.dts = mpegts.ExtractTime(pesBytes[14:19])
 				}
 			}
 
@@ -196,7 +198,7 @@ func (pes *pESHeader) Data() []byte {
 }
 
 func (pes *pESHeader) HasPTS() bool {
-	return (pes.ptsDtsIndicator & PTS_DTS_INDICATOR_ONLY_PTS) != 0
+	return (pes.ptsDtsIndicator & mpegts.PTS_DTS_INDICATOR_ONLY_PTS) != 0
 }
 
 func (pes *pESHeader) Format() string {
@@ -213,9 +215,9 @@ func (pes *pESHeader) Format() string {
 	if pes.optionalFieldsExist() {
 		ptsDtsIndicator := pes.ptsDtsIndicator
 		f += fmt.Sprintf("PTS DTS Indicator: %b\n", pes.ptsDtsIndicator)
-		if ptsDtsIndicator == PTS_DTS_INDICATOR_BOTH || ptsDtsIndicator == PTS_DTS_INDICATOR_ONLY_PTS {
+		if ptsDtsIndicator == mpegts.PTS_DTS_INDICATOR_BOTH || ptsDtsIndicator == mpegts.PTS_DTS_INDICATOR_ONLY_PTS {
 			f += fmt.Sprintf("PTS: %d\n", pes.pts)
-			if ptsDtsIndicator == PTS_DTS_INDICATOR_BOTH {
+			if ptsDtsIndicator == mpegts.PTS_DTS_INDICATOR_BOTH {
 				f += fmt.Sprintf("DTS: %d\n", pes.dts)
 			}
 		}

--- a/pts_test.go
+++ b/pts_test.go
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
-package pes
+package mpegts
 
 import "testing"
 
@@ -116,4 +116,14 @@ func TestAdd(t *testing.T) {
 	if PTS(2000) != PTS(1500).Add(PTS(500)) {
 		t.Error("PTS addition 2 test failed")
 	}
+}
+
+func TestInsertPTS(t *testing.T) {
+	var pts uint64 = 0x1DEADBEEF
+	b := make([]byte, 5)
+	InsertPTS(b, pts)
+	if ExtractTime(b) != 0x1DEADBEEF {
+		t.Error("Insert PTS test 1 failed")
+	}
+
 }

--- a/scte35/doc.go
+++ b/scte35/doc.go
@@ -25,9 +25,7 @@ SOFTWARE.
 // Package scte35 is for handling scte35 splice signals
 package scte35
 
-import (
-	"github.com/comcast/gots/pes"
-)
+import "github.com/comcast/gots"
 
 // SpliceCommandType - not really needed for processing but included for
 // backwards compatibility/porting
@@ -107,7 +105,7 @@ type SCTE35 interface {
 	// HasPTS returns true if there is a pts time
 	HasPTS() bool
 	// PTS returns the PTS time of the signal if it exists
-	PTS() pes.PTS
+	PTS() mpegts.PTS
 	// Command returns the signal's splice command
 	Command() SpliceCommandType
 	// Descriptors returns a slice of the signals SegmentationDescriptors
@@ -148,7 +146,7 @@ type SegmentationDescriptor interface {
 	// HasDuration returns true if there is a duration associated with the descriptor
 	HasDuration() bool
 	// Duration returns the duration of the descriptor
-	Duration() pes.PTS
+	Duration() mpegts.PTS
 	// UPIDType returns the type of the upid
 	UPIDType() SegUPIDType
 	// UPID returns the upid of the descriptor

--- a/scte35/scte35.go
+++ b/scte35/scte35.go
@@ -29,7 +29,6 @@ import (
 	"encoding/binary"
 
 	"github.com/comcast/gots"
-	"github.com/comcast/gots/pes"
 	"github.com/comcast/gots/psi"
 )
 
@@ -45,7 +44,7 @@ type segmentationDescriptor struct {
 	typeID       SegDescType
 	eventID      uint32
 	hasDuration  bool
-	duration     pes.PTS
+	duration     mpegts.PTS
 	upidType     SegUPIDType
 	upid         []byte
 	segNum       uint8
@@ -56,7 +55,7 @@ type segmentationDescriptor struct {
 type scte35 struct {
 	command     SpliceCommandType
 	hasPTS      bool
-	pts         pes.PTS
+	pts         mpegts.PTS
 	descriptors []SegmentationDescriptor
 
 	data []byte
@@ -208,7 +207,7 @@ func (s *scte35) HasPTS() bool {
 	return s.hasPTS
 }
 
-func (s *scte35) PTS() pes.PTS {
+func (s *scte35) PTS() mpegts.PTS {
 	return s.pts
 }
 
@@ -260,7 +259,7 @@ func (d *segmentationDescriptor) HasDuration() bool {
 	return d.hasDuration
 }
 
-func (d *segmentationDescriptor) Duration() pes.PTS {
+func (d *segmentationDescriptor) Duration() mpegts.PTS {
 	return d.duration
 }
 
@@ -345,6 +344,6 @@ func abs(num int8) int8 {
 	}
 }
 
-func uint40(buf []byte) pes.PTS {
-	return (pes.PTS(buf[0]&0x1) << 32) | (pes.PTS(buf[1]) << 24) | (pes.PTS(buf[2]) << 16) | (pes.PTS(buf[3]) << 8) | (pes.PTS(buf[4]))
+func uint40(buf []byte) mpegts.PTS {
+	return (mpegts.PTS(buf[0]&0x1) << 32) | (mpegts.PTS(buf[1]) << 24) | (mpegts.PTS(buf[2]) << 16) | (mpegts.PTS(buf[3]) << 8) | (mpegts.PTS(buf[4]))
 }


### PR DESCRIPTION
 - Fixes InsertPTS to correctly insert the PTS time provided
 - Adds unit test to test InsertPTS
 - Moved pts.go to root level; it's used by scte35 as well
 - Moved ExtractTime to pts.go so all the PTS utilites are in one place