### PR TITLE
Basic support for MPTS

### DIFF
--- a/psi/doc.go
+++ b/psi/doc.go
@@ -81,6 +81,8 @@ type PmtStreamType interface {
 // PAT interface represents operations on a Program Association Table. Currently only single program transport streams (SPTS)are supported
 type PAT interface {
 	NumPrograms() int
+	ProgramMapPid() uint16 // DEPRECATED
+	ProgramNumber() uint16 // DEPRECATED
 	ProgramMap() map[uint16]uint16
 }
 

--- a/psi/doc.go
+++ b/psi/doc.go
@@ -81,8 +81,7 @@ type PmtStreamType interface {
 // PAT interface represents operations on a Program Association Table. Currently only single program transport streams (SPTS)are supported
 type PAT interface {
 	NumPrograms() int
-	ProgramMapPid() uint16
-	ProgramNumber() uint16
+	ProgramMap() map[uint16]uint16
 }
 
 // PMT is a Program Map Table.

--- a/psi/pat.go
+++ b/psi/pat.go
@@ -73,6 +73,38 @@ func (pat pat) NumPrograms() int {
 	return numPrograms
 }
 
+// DEPRECATED - use ProgramMap for new code
+func (pat pat) ProgramMapPid() uint16 {
+	if pat.NumPrograms() != 1 {
+		// This method has undefined behavior for multi program transport streams.
+		// Please use pat.ProgramMap() for a map of PNs and PIDs for PMTs
+		return 8192
+	}
+
+	pm := pat.ProgramMap()
+	for _, v := range pm {
+		return v
+	}
+
+	return 8192
+}
+
+// DEPRECATED - use ProgramMap for new code
+func (pat pat) ProgramNumber() uint16 {
+	if pat.NumPrograms() != 1 {
+		// This method has undefined behavior for multi program transport streams.
+		// Please use pat.ProgramMap() for a map of PNs and PIDs for PMTs
+		return 0
+	}
+
+	pm := pat.ProgramMap()
+	for k := range pm {
+		return k
+	}
+
+	return 0
+}
+
 // ProgramMap returns a map of program numbers and PIDs of the PMTs
 func (pat pat) ProgramMap() map[uint16]uint16 {
 	m := make(map[uint16]uint16)

--- a/psi/pat.go
+++ b/psi/pat.go
@@ -73,12 +73,22 @@ func (pat pat) NumPrograms() int {
 	return numPrograms
 }
 
-// ProgramMapPid returns the PID of the PMT
-func (pat pat) ProgramMapPid() uint16 {
-	return (uint16(pat[11]) & 0x1f << 8) | uint16(pat[12])
-}
+// ProgramMap returns a map of program numbers and PIDs of the PMTs
+func (pat pat) ProgramMap() map[uint16]uint16 {
+	m := make(map[uint16]uint16)
 
-// ProgramNumber returns the program number for this PAT
-func (pat pat) ProgramNumber() uint16 {
-	return (uint16(pat[9]) << 8) | uint16(pat[10])
+	counter := 8 // skip table id et al
+
+	for i := 0; i < pat.NumPrograms(); i++ {
+		pn := (uint16(pat[counter+1]) << 8) | uint16(pat[counter+2])
+
+		// ignore the top three (reserved) bits
+		pid := uint16(pat[counter+3])&0x1f<<8 | uint16(pat[counter+4])
+
+		m[pn] = pid
+
+		counter += 4
+	}
+
+	return m
 }

--- a/psi/pat_test.go
+++ b/psi/pat_test.go
@@ -1,0 +1,107 @@
+/*
+MIT License
+
+Copyright 2016 Comcast Cable Communications Management, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+package psi
+
+import (
+	"encoding/hex"
+	"reflect"
+	"testing"
+)
+
+var testData = []struct {
+	patBytes          string
+	wantStreams       int
+	wantProgramNumber uint16
+	wantProgramMapPID uint16
+	wantProgramMap    map[uint16]uint16
+}{
+	{"0000b00d0000c100000001e064dee0f320", 1, 1, 100, map[uint16]uint16{1: 100}},
+	{"0000b0150000c100000001e0640002e0c80003e12ce8f16345", 3, 0, 8192, map[uint16]uint16{1: 100, 2: 200, 3: 300}},
+}
+
+func TestNumPrograms(t *testing.T) {
+	for _, test := range testData {
+		pat_bytes, _ := hex.DecodeString(test.patBytes)
+
+		pat, err := NewPAT(pat_bytes)
+		if err != nil {
+			t.Errorf("Can't parse PAT table %v", err)
+		}
+
+		gotStreams := pat.NumPrograms()
+		if test.wantStreams != gotStreams {
+			t.Errorf("Invalid number of streams! got %v, want %v", gotStreams, test.wantStreams)
+		}
+	}
+}
+
+// ProgramMapPid is DEPRECATED - new code should use ProgramMap
+func TestProgramMapPid(t *testing.T) {
+	for _, test := range testData {
+		pat_bytes, _ := hex.DecodeString(test.patBytes)
+
+		pat, err := NewPAT(pat_bytes)
+		if err != nil {
+			t.Errorf("Can't parse PAT table %v", err)
+		}
+
+		gotPMPID := pat.ProgramMapPid()
+		if test.wantProgramMapPID != gotPMPID {
+			t.Errorf("Wrong Program Map PID! got %v, want %v", gotPMPID, test.wantProgramMapPID)
+		}
+	}
+}
+
+// ProgramNumber is DEPRECATED - new code should use ProgramMap
+func TestProgramNumber(t *testing.T) {
+	for _, test := range testData {
+		pat_bytes, _ := hex.DecodeString(test.patBytes)
+
+		pat, err := NewPAT(pat_bytes)
+		if err != nil {
+			t.Errorf("Can't parse PAT table %v", err)
+		}
+
+		gotPN := pat.ProgramNumber()
+		if test.wantProgramNumber != gotPN {
+			t.Errorf("Wrong Program Number! got %v, want %v", gotPN, test.wantProgramNumber)
+		}
+	}
+}
+
+func TestProgramMap(t *testing.T) {
+	for _, test := range testData {
+		pat_bytes, _ := hex.DecodeString(test.patBytes)
+
+		pat, err := NewPAT(pat_bytes)
+		if err != nil {
+			t.Errorf("Can't parse PAT table %v", err)
+		}
+
+		gotMap := pat.ProgramMap()
+		if !reflect.DeepEqual(test.wantProgramMap, gotMap) {
+			t.Errorf("Wrong Program Map! got %v, want %v", gotMap, test.wantProgramMap)
+		}
+	}
+}

--- a/psi/pmt.go
+++ b/psi/pmt.go
@@ -61,7 +61,6 @@ func NewPMT(pmtBytes []byte) (PMT, error) {
 		return nil, err
 	}
 	return pmt, nil
-
 }
 
 func (p *pmt) parseTable(pmtBytes []byte) error {
@@ -132,12 +131,14 @@ func (p *pmt) RemoveElementaryStreams(removePids []uint16) {
 			}
 		}
 	}
+
 	var filteredPids []uint16
+
 	for _, es := range p.elementaryStreams {
 		filteredPids = append(filteredPids, es.ElementaryPid())
 	}
-	p.pids = filteredPids
 
+	p.pids = filteredPids
 }
 
 func (p *pmt) IsPidForStreamWherePresentationLagsEbp(pid uint16) bool {
@@ -262,20 +263,23 @@ func FilterPMTPacketsToPids(packets []packet.Packet, pids []uint16) []packet.Pac
 // of pkt.
 func IsPMT(pkt packet.Packet, pat PAT) (bool, error) {
 	if pat == nil {
-
 		return false, gots.ErrNilPAT
 	}
 
-	pmtPid := pat.ProgramMapPid()
+	pmtMap := pat.ProgramMap()
 	pid, err := packet.Pid(pkt)
 
 	if err != nil {
-
 		return false, err
 	}
 
-	return pid == pmtPid, nil
+	for _, map_pid := range pmtMap {
+		if pid == map_pid {
+			return true, nil
+		}
+	}
 
+	return false, nil
 }
 
 func safeSlice(byteArray []byte, start, end int) []byte {
@@ -297,5 +301,6 @@ func pidIn(pids []uint16, target uint16) bool {
 			return true
 		}
 	}
+
 	return false
 }


### PR DESCRIPTION
Contains a **breaking change**:

Removes `pat.ProgramMapPid()` and `pat.ProgramNumber()` in favor of a single `pat.ProgramMap()` that returns a `map[uint16]uint16` of the program numbers and associated PIDs.

That said, it's easy to keep the methods around if they are needed or wanted, but I think returning the map is probably more correct.