### PR TITLE
Changes to support segmentation descriptors with event_cancel_indicator == 1.

### DIFF
--- a/scte35/doc.go
+++ b/scte35/doc.go
@@ -125,6 +125,8 @@ type SegmentationDescriptor interface {
 	EventID() uint32
 	// TypeID returns the segmentation type for descriptor
 	TypeID() SegDescType
+	// IsEventCanceled returns the event cancel indicator
+	IsEventCanceled() bool
 	// IsOut returns true if a signal is an out
 	IsOut() bool
 	// IsIn returns true if a signal is an in

--- a/scte35/scte35.go
+++ b/scte35/scte35.go
@@ -36,7 +36,6 @@ import (
 const (
 	segDescTag = 0x02
 	segDescID  = 0x43554549
-	minDescLen = 15 // min desc len does not include descriptor tag or len
 )
 
 type scte35 struct {
@@ -120,7 +119,7 @@ func (s *scte35) parseTable(data []byte) error {
 			descTag := readByte()
 			descLen := readByte()
 			// Make sure a bad descriptorLen doesn't kill us
-			if descLoopLen-bytesRead-2 < uint16(descLen) || descLen < minDescLen {
+			if descLoopLen-bytesRead-2 < uint16(descLen) {
 				return gots.ErrInvalidSCTE35Length
 			}
 			if descTag != segDescTag {

--- a/scte35/scte35_test.go
+++ b/scte35/scte35_test.go
@@ -265,3 +265,37 @@ func TestSCTEMultipleDescriptors(t *testing.T) {
 		t.Error("SCTE obj of both descs is not the same")
 	}
 }
+
+func TestParseSegmentationDescriptor_EventCancelled(t *testing.T) {
+	base64Bytes, _ := base64.StdEncoding.DecodeString("APwwKwAATJCc6v//8AUG/vafrY0AFQIJQ1VFSQAAAAD/AAhDVUVJAAAAAEBlk0M=")
+
+	s, err := NewSCTE35(base64Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if s.Command() != TimeSignal {
+		t.Errorf("Invalid command found, expecting TimeSignal(6), got: %v", s.Command())
+	}
+
+	if !s.HasPTS() {
+		t.Error("Expecting PTS, but none found")
+	}
+
+	if s.PTS() != gots.PTS(5422205559) {
+		t.Errorf("Expected PTS 5422205559, got: %v", s.PTS())
+	}
+
+	if len(s.Descriptors()) != 1 {
+		t.Errorf("Expected 1 segmentation descriptor, got %d", s.Descriptors())
+	}
+
+	segmentationDescriptor := s.Descriptors()[0]
+	if segmentationDescriptor.TypeID() != SegDescNotIndicated {
+		t.Errorf("Expected segmentationtype Not Indicated, got %s", segmentationDescriptor.TypeID())
+	}
+
+	if !segmentationDescriptor.IsEventCanceled() {
+		t.Error("Expected event to be canceled.")
+	}
+}


### PR DESCRIPTION
- Removed minimum segmentation descriptor length to accommodate these shorted descriptors.
- Added IsEventCanceled() method to SegmentationDescriptor interface.