### PR TITLE
scte35: roll over splice command pts using PTS.Add

### DIFF
--- a/scte35/scte35.go
+++ b/scte35/scte35.go
@@ -99,7 +99,7 @@ func (s *scte35) parseTable(data []byte) error {
 				return err
 			}
 			// add the pts adjustment to get the real value
-			s.pts = cmd.PTS() + ptsAdjustment
+			s.pts = cmd.PTS().Add(ptsAdjustment)
 			s.hasPTS = cmd.HasPTS()
 			s.commandInfo = cmd
 		case SpliceNull:


### PR DESCRIPTION
The final derived PTS for SCTE35 command (calculated from pts in command plus adjustment in header) should roll over and not go beyond the PTS size limit of 33 bits. This just uses PTS logic already in place to do the add.