### PR TITLE
Adds h262 stream type constant

### DIFF
--- a/psi/doc.go
+++ b/psi/doc.go
@@ -27,6 +27,7 @@ package psi
 
 // Stream type constants
 const (
+	PmtStreamTypeMpeg2VideoH262 uint8 = 2  // H262
 	PmtStreamTypeMpeg4Video     uint8 = 27 // H264
 	PmtStreamTypeMpeg4VideoH264 uint8 = 27 // H264
 	PmtStreamTypeMpeg4VideoH265 uint8 = 36 // H265


### PR DESCRIPTION
Per ISO13818-1 § 2.4.4.9 / Table 2-34, the value `0x02` is:
>   Rec. ITU-T H.262 | ISO/IEC 13818-2 Video or ISO/IEC
>   11172-2 constrained parameter video stream (see Note 2)

Note 2:
>   Rec. ITU-T H.262 | ISO/IEC 13818-2 video with frame
>   packing arrangement information is signalled using
>   stream_type value 0x02.