### PR TITLE
Add option for SCTE35 parsing to CLI

### DIFF
--- a/cli/parsefile.go
+++ b/cli/parsefile.go
@@ -181,7 +181,7 @@ func printSCTE35(msg scte35.SCTE35) {
 }
 
 func printSpliceCommand(spliceCommand scte35.SpliceCommand) {
-	printlnf("\tCommand Type %v", spliceCommand.CommandType())
+	printlnf("\tCommand Type %v", scte35.SpliceCommandTypeNames[spliceCommand.CommandType()])
 	if spliceCommand.HasPTS() {
 
 		printlnf("\tPTS %v", spliceCommand.PTS())

--- a/cli/parsefile.go
+++ b/cli/parsefile.go
@@ -37,6 +37,7 @@ import (
 	"github.com/Comcast/gots/packet"
 	"github.com/Comcast/gots/packet/adaptationfield"
 	"github.com/Comcast/gots/psi"
+	"github.com/Comcast/gots/scte35"
 )
 
 // main parses a ts file that is provided with the -f flag
@@ -44,6 +45,7 @@ func main() {
 	fileName := flag.String("f", "", "Required: Path to TS file to read")
 	showPmt := flag.Bool("pmt", true, "Output PMT info")
 	showEbp := flag.Bool("ebp", false, "Output EBP info. This is a lot of info")
+	dumpSCTE35 := flag.Bool("scte35", false, "Output SCTE35 signals and info.")
 	showPacketNumberOfPID := flag.Int("pid", 0, "Dump the contents of the first packet encountered on PID to stdout")
 	flag.Parse()
 	if *fileName == "" {
@@ -75,13 +77,15 @@ func main() {
 	}
 	printPat(pat)
 
-	if *showPmt {
-		pm := pat.ProgramMap()
-		for pn, pid := range pm {
-			pmt, err := psi.ReadPMT(reader, pid)
-			if err != nil {
-				panic(err)
-			}
+	var pmts []psi.PMT
+	pm := pat.ProgramMap()
+	for pn, pid := range pm {
+		pmt, err := psi.ReadPMT(reader, pid)
+		if err != nil {
+			panic(err)
+		}
+		pmts = append(pmts, pmt)
+		if *showPmt {
 			printPmt(pn, pmt)
 		}
 	}
@@ -98,6 +102,37 @@ func main() {
 			return
 		}
 		numPackets++
+		if *dumpSCTE35 {
+			var scte35PID uint16
+			currPID, err := packet.Pid(pkt)
+			if err != nil {
+				printlnf("Cannot get packet PID for %d", currPID)
+				continue
+			}
+			// assuming SPTS
+			for _, es := range pmts[0].ElementaryStreams() {
+				if es.StreamType() == psi.PmtStreamTypeScte35 {
+					scte35PID = es.ElementaryPid()
+					break
+				}
+
+			}
+			if currPID == scte35PID {
+				pay, err := packet.Payload(pkt)
+				if err != nil {
+					printlnf("Cannot get payload for packet number %d on PID %d Error=%s", numPackets, currPID, err)
+					continue
+				}
+				msg, err := scte35.NewSCTE35(pay)
+				if err != nil {
+					printlnf("Cannot parse SCTE35 Error=%v", err)
+					continue
+				}
+				printSCTE35(msg)
+
+			}
+
+		}
 		if *showEbp {
 			ebpBytes, err := adaptationfield.EncoderBoundaryPoint(pkt)
 			if err != nil {
@@ -127,6 +162,59 @@ func main() {
 	}
 	println()
 
+}
+
+func printSCTE35(msg scte35.SCTE35) {
+	printlnf("SCTE35 Message")
+
+	printSpliceCommand(msg.CommandInfo())
+
+	insert, ok := msg.CommandInfo().(scte35.SpliceInsertCommand)
+	if ok {
+
+		printSpliceInsertCommand(insert)
+	}
+	for _, segdesc := range msg.Descriptors() {
+		printSegDesc(segdesc)
+	}
+
+}
+
+func printSpliceCommand(spliceCommand scte35.SpliceCommand) {
+	printlnf("\tCommand Type %v", spliceCommand.CommandType())
+	if spliceCommand.HasPTS() {
+
+		printlnf("\tPTS %v", spliceCommand.PTS())
+
+	}
+}
+
+func printSegDesc(segdesc scte35.SegmentationDescriptor) {
+	if segdesc.IsIn() {
+
+		printlnf("\t<--- IN Segmentation Descriptor")
+	}
+	if segdesc.IsOut() {
+
+		printlnf("\t---> OUT Segmentation Descriptor")
+	}
+
+	printlnf("\t\tEvent ID %d", segdesc.EventID())
+	printlnf("\t\tType %+v", scte35.SegDescTypeNames[segdesc.TypeID()])
+	if segdesc.HasDuration() {
+
+		printlnf("\t\t Duration %v", segdesc.Duration())
+	}
+
+}
+
+func printSpliceInsertCommand(insert scte35.SpliceInsertCommand) {
+	println("\tSplice Insert Command")
+	printlnf("\t\tEvent ID %v", insert.EventID())
+	if insert.HasDuration() {
+		printlnf("\t\tDuration %v", insert.Duration())
+
+	}
 }
 
 func printPmt(pn uint16, pmt psi.PMT) {

--- a/scte35/doc.go
+++ b/scte35/doc.go
@@ -47,6 +47,15 @@ const (
 	PrivateCommand = 0xFF
 )
 
+var SpliceCommandTypeNames = map[SpliceCommandType]string{
+	SpliceNull:           "SpliceNull",
+	SpliceSchedule:       "SpliceSchedule",
+	SpliceInsert:         "SpliceInsert",
+	TimeSignal:           "TimeSignal",
+	BandwidthReservation: "BandwidthReservation",
+	PrivateCommand:       "PrivateCommand",
+}
+
 // SegDescType is the Segmentation Descriptor Type - not really needed for processing according
 // to method below, but included here for backwards compatibility/porting
 type SegDescType uint8

--- a/scte35/doc.go
+++ b/scte35/doc.go
@@ -79,6 +79,34 @@ const (
 	SegDescNetworkEnd                                = 0x51
 )
 
+var SegDescTypeNames = map[SegDescType]string{
+	SegDescNotIndicated:                  "SegDescNotIndicated",
+	SegDescContentIdentification:         "SegDescContentIdentification",
+	SegDescProgramStart:                  "SegDescProgramStart",
+	SegDescProgramEnd:                    "SegDescProgramEnd",
+	SegDescProgramEarlyTermination:       "SegDescProgramEarlyTermination",
+	SegDescProgramBreakaway:              "SegDescProgramBreakaway",
+	SegDescProgramResumption:             "SegDescProgramResumption",
+	SegDescProgramRunoverPlanned:         "SegDescProgramRunoverPlanned",
+	SegDescProgramRunoverUnplanned:       "SegDescProgramRunoverUnplanned",
+	SegDescProgramOverlapStart:           "SegDescProgramOverlapStart",
+	SegDescProgramBlackoutOverride:       "SegDescProgramBlackoutOverride",
+	SegDescChapterStart:                  "SegDescChapterStart",
+	SegDescChapterEnd:                    "SegDescChapterEnd",
+	SegDescProviderAdvertisementStart:    "SegDescProviderAdvertisementStar",
+	SegDescProviderAdvertisementEnd:      "SegDescProviderAdvertisementEn",
+	SegDescDistributorAdvertisementStart: "SegDescDistributorAdvertisementStar",
+	SegDescDistributorAdvertisementEnd:   "SegDescDistributorAdvertisementEn",
+	SegDescProviderPOStart:               "SegDescProviderPOStart",
+	SegDescProviderPOEnd:                 "SegDescProviderPOEnd",
+	SegDescDistributorPOStart:            "SegDescDistributorPOStart",
+	SegDescDistributorPOEnd:              "SegDescDistributorPOEnd",
+	SegDescUnscheduledEventStart:         "SegDescUnscheduledEventStart",
+	SegDescUnscheduledEventEnd:           "SegDescUnscheduledEventEnd",
+	SegDescNetworkStart:                  "SegDescNetworkStart",
+	SegDescNetworkEnd:                    "SegDescNetworkE",
+}
+
 // SegUPIDType is the Segmentation UPID Types - Only type that really needs to be checked is
 // SegUPIDURN for CSP
 type SegUPIDType uint8


### PR DESCRIPTION
Using the `-scte35` flag, you can dump all the SCTE35 signals using the CLI.