### PR TITLE
SCTE.DATA() starts with table id and does not include pointer field

### DIFF
--- a/scte35/scte35.go
+++ b/scte35/scte35.go
@@ -140,7 +140,9 @@ func (s *scte35) parseTable(data []byte) error {
 		return gots.ErrUnknownTableID
 	}
 	// Check CRC?
-	s.data = data
+	//remove the pointer field and associated data off the top so we only get the
+	//table data
+	s.data = data[psi.PointerField(data)+1:]
 	return nil
 }
 

--- a/scte35/scte35_test.go
+++ b/scte35/scte35_test.go
@@ -144,6 +144,10 @@ func TestBasicSignal(t *testing.T) {
 			t.Error("non-zero len upid found, indicating error")
 		}
 	}
+	data := s.Data()
+	if data[0] != 0xfc {
+		t.Error("First byte of data is not table id")
+	}
 }
 
 // splice_null commands are used for CSP.


### PR DESCRIPTION
code and test