### PR TITLE
Adding MID parsing for signal stream switching scte35 signals

### DIFF
--- a/scte35/doc.go
+++ b/scte35/doc.go
@@ -220,6 +220,8 @@ type SegmentationDescriptor interface {
 	UPIDType() SegUPIDType
 	// UPID returns the upid of the descriptor
 	UPID() []byte
+	// StreamSwitchSignalID returns the signalID of StreamsSwitch signal if present
+	StreamSwitchSignalId() string
 	// CanClose returns true if this descriptor can close the passed in descriptor
 	CanClose(out SegmentationDescriptor) bool
 	// Equal returns true/false if segmentation descriptor is functionally

--- a/scte35/segmentationdescriptor.go
+++ b/scte35/segmentationdescriptor.go
@@ -27,9 +27,17 @@ package scte35
 import (
 	"bytes"
 	"encoding/binary"
+	"strings"
 
 	"github.com/Comcast/gots"
 )
+
+// This is the struct used for creating a Multiple UPID
+type uid struct {
+	upidType SegUPIDType
+	upidLen  int
+	upid     []byte
+}
 
 type segmentationDescriptor struct {
 	// common fields we care about for sorting/identifying, but is not necessarily needed for users of this lib
@@ -39,6 +47,7 @@ type segmentationDescriptor struct {
 	duration             gots.PTS
 	upidType             SegUPIDType
 	upid                 []byte
+	mid                  [2]uid //A MID contains 2 UID's in it.
 	segNum               uint8
 	segsExpected         uint8
 	subSegNum            uint8
@@ -86,7 +95,7 @@ func init() {
 		0x36: {0x30: segCloseDiffPTS, 0x32: segCloseDiffPTS, 0x36: segCloseNotNested},
 		0x37: {0x30: segCloseNormal, 0x32: segCloseNormal, 0x36: segCloseEventIDNotNested},
 		0x40: {0x40: segCloseNormal},
-		0x41: {0x40: segCloseEventID},
+		0x41: {0x41: segCloseNormal},
 		0x50: {0x10: segCloseNormal, 0x14: segCloseNormal, 0x17: segCloseNormal, 0x19: segCloseNormal, 0x20: segCloseNormal, 0x30: segCloseNormal, 0x32: segCloseNormal, 0x34: segCloseNormal, 0x36: segCloseNormal, 0x40: segCloseUnconditional, 0x50: segCloseNormal},
 		0x51: {0x10: segCloseNormal, 0x14: segCloseNormal, 0x17: segCloseNormal, 0x19: segCloseNormal, 0x20: segCloseNormal, 0x30: segCloseNormal, 0x32: segCloseNormal, 0x34: segCloseNormal, 0x36: segCloseNormal, 0x40: segCloseUnconditional, 0x50: segCloseEventID},
 	}
@@ -137,10 +146,24 @@ func (d *segmentationDescriptor) parseDescriptor(data []byte) error {
 		// upid unneeded now...
 		d.upidType = SegUPIDType(readByte())
 		upidLen := int(readByte())
-		if buf.Len() < upidLen+3 {
-			return gots.ErrInvalidSCTE35Length
+		if d.upidType == 0x0d {
+			// This is a Multiple PID, consisting of 2 PID's
+			// SCTE35 can either have a UPID or a MID so the UPID can be 0.
+			d.upid = []byte{}
+			for i := 0; i <= 1; i++ {
+				d.mid[i].upidType = SegUPIDType(readByte())
+				d.mid[i].upidLen = int(readByte())
+				d.mid[i].upid = buf.Next(d.mid[i].upidLen)
+			}
+		} else {
+			// This is a UPID, not a MID
+			// MID should be 0 as SCTE35 can either have a UPID or a MID
+			d.mid = [2]uid{}
+			if buf.Len() < upidLen+3 {
+				return gots.ErrInvalidSCTE35Length
+			}
+			d.upid = buf.Next(upidLen)
 		}
-		d.upid = buf.Next(upidLen)
 		d.typeID = SegDescType(readByte())
 		d.segNum = readByte()
 		d.segsExpected = readByte()
@@ -227,6 +250,16 @@ func (d *segmentationDescriptor) UPIDType() SegUPIDType {
 
 func (d *segmentationDescriptor) UPID() []byte {
 	return d.upid
+}
+
+func (d *segmentationDescriptor) StreamSwitchSignalId() string {
+	var signalId string
+	// SignalId is present in the MID.
+	if len(d.mid) == 2 {
+		// SignalId is the 1st UPID in the MID without the leading "BLACKOUT:"
+		signalId = strings.TrimPrefix(string(d.mid[0].upid), "BLACKOUT:")
+	}
+	return signalId
 }
 
 func (d *segmentationDescriptor) CanClose(out SegmentationDescriptor) bool {

--- a/scte35/state.go
+++ b/scte35/state.go
@@ -142,9 +142,12 @@ func (s *state) ProcessDescriptor(desc SegmentationDescriptor) ([]SegmentationDe
 			}
 		}
 	case SegDescChapterEnd,
-		SegDescProviderAdvertisementEnd, SegDescProviderPOEnd,
-		SegDescDistributorAdvertisementEnd, SegDescDistributorPOEnd,
-		SegDescUnscheduledEventEnd, SegDescNetworkEnd:
+		SegDescProviderAdvertisementEnd,
+		SegDescProviderPOEnd,
+		SegDescDistributorAdvertisementEnd,
+		SegDescDistributorPOEnd,
+		SegDescUnscheduledEventEnd,
+		SegDescNetworkEnd:
 		var openDesc SegmentationDescriptor
 		// descriptor matches out, but doesn't close it.  Check event id against open
 		if len(closed) == 0 || closed[len(closed)-1].TypeID() != desc.TypeID()-1 {


### PR DESCRIPTION
Some information about the MID.
Stream switch signals always contain both of the following segmentation descriptors
Segmentation Message        segmentation_type_id
Unscheduled Event Start	0x40
Unscheduled Event End	0x41

segmentation_upid() field with segmentation_upid_type 0x0D (MID) containing the following individual UPIDs
1. segmentation_upid_type 0x09 (ADI).
ADI UPID value of "BLACKOUT:<base64-encoded signalID>"
2. segmentation_upid_type equals 0x0E (ADS).
ADS UPID value of "comcast:linear:licenserotation"