### PR TITLE
Changes to processing license rotation SCTE35 signals to be ESAM compliant.

### DIFF
--- a/scte35/doc.go
+++ b/scte35/doc.go
@@ -220,7 +220,8 @@ type SegmentationDescriptor interface {
 	UPIDType() SegUPIDType
 	// UPID returns the upid of the descriptor
 	UPID() []byte
-	// StreamSwitchSignalID returns the signalID of StreamsSwitch signal if present
+	// StreamSwitchSignalID returns the signalID of streamswitch signal if
+	// present in the descriptor
 	StreamSwitchSignalId() string
 	// CanClose returns true if this descriptor can close the passed in descriptor
 	CanClose(out SegmentationDescriptor) bool

--- a/scte35/segmentationdescriptor.go
+++ b/scte35/segmentationdescriptor.go
@@ -268,6 +268,7 @@ func (d *segmentationDescriptor) StreamSwitchSignalId() string {
 		upidStr := string(d.mid[i].upid)
 		if strings.Contains(upidStr, "BLACKOUT") {
 			signalId = strings.TrimPrefix(upidStr, "BLACKOUT:")
+			break
 		}
 	}
 	return signalId

--- a/scte35/segmentationdescriptor.go
+++ b/scte35/segmentationdescriptor.go
@@ -33,7 +33,7 @@ import (
 )
 
 // This is the struct used for creating a Multiple UPID (MID)
-type uid struct {
+type upidSt struct {
 	upidType SegUPIDType
 	upidLen  int
 	upid     []byte
@@ -47,7 +47,7 @@ type segmentationDescriptor struct {
 	duration             gots.PTS
 	upidType             SegUPIDType
 	upid                 []byte
-	mid                  [2]uid //A MID contains 2 UPID uids in it.
+	mid                  []upidSt //A MID can contains `n` UPID uids in it.
 	segNum               uint8
 	segsExpected         uint8
 	subSegNum            uint8
@@ -95,7 +95,7 @@ func init() {
 		0x36: {0x30: segCloseDiffPTS, 0x32: segCloseDiffPTS, 0x36: segCloseNotNested},
 		0x37: {0x30: segCloseNormal, 0x32: segCloseNormal, 0x36: segCloseEventIDNotNested},
 		0x40: {0x40: segCloseNormal},
-		0x41: {0x41: segCloseNormal},
+		0x41: {0x40: segCloseEventID},
 		0x50: {0x10: segCloseNormal, 0x14: segCloseNormal, 0x17: segCloseNormal, 0x19: segCloseNormal, 0x20: segCloseNormal, 0x30: segCloseNormal, 0x32: segCloseNormal, 0x34: segCloseNormal, 0x36: segCloseNormal, 0x40: segCloseUnconditional, 0x50: segCloseNormal},
 		0x51: {0x10: segCloseNormal, 0x14: segCloseNormal, 0x17: segCloseNormal, 0x19: segCloseNormal, 0x20: segCloseNormal, 0x30: segCloseNormal, 0x32: segCloseNormal, 0x34: segCloseNormal, 0x36: segCloseNormal, 0x40: segCloseUnconditional, 0x50: segCloseEventID},
 	}
@@ -145,25 +145,32 @@ func (d *segmentationDescriptor) parseDescriptor(data []byte) error {
 		}
 		// upid unneeded now...
 		d.upidType = SegUPIDType(readByte())
-		upidLen := int(readByte())
+		segUpidLen := int(readByte())
+		d.mid = []upidSt{}
+		// This is a Multiple PID, consisting of `n` UPID's
 		if d.upidType == 0x0d {
-			// This is a Multiple PID, consisting of 2 UPID's
-			// SCTE35 can either have a UPID or a MID
-			// When we have a MID, the UPID will be 0.
+			// SCTE35 signal will either have an UPID or a MID
+			// When we have a MID, UPID value in struct will be 0.
 			d.upid = []byte{}
-			for i := 0; i <= 1; i++ {
-				d.mid[i].upidType = SegUPIDType(readByte())
-				d.mid[i].upidLen = int(readByte())
-				d.mid[i].upid = buf.Next(d.mid[i].upidLen)
+			// Iterate over the whole MID len(segUpidLen) to get all `n` UPIDs
+			// segUpidLen is in bytes.
+			for segUpidLen != 0 {
+				upidElem := upidSt{}
+				upidElem.upidType = SegUPIDType(readByte())
+				segUpidLen -= 1
+				upidElem.upidLen = int(readByte())
+				segUpidLen -= 1
+				upidElem.upid = buf.Next(upidElem.upidLen)
+				segUpidLen -= upidElem.upidLen
+				d.mid = append(d.mid, upidElem)
 			}
 		} else {
 			// This is a UPID, not a MID
 			// MID should be 0 as SCTE35 can either have a UPID or a MID
-			d.mid = [2]uid{}
-			if buf.Len() < upidLen+3 {
+			if buf.Len() < segUpidLen+3 {
 				return gots.ErrInvalidSCTE35Length
 			}
-			d.upid = buf.Next(upidLen)
+			d.upid = buf.Next(segUpidLen)
 		}
 		d.typeID = SegDescType(readByte())
 		d.segNum = readByte()
@@ -255,10 +262,13 @@ func (d *segmentationDescriptor) UPID() []byte {
 
 func (d *segmentationDescriptor) StreamSwitchSignalId() string {
 	var signalId string
-	// SignalId is present in the MID.
-	if len(d.mid) == 2 {
-		// SignalId is the 1st UPID in the MID without the leading "BLACKOUT:"
-		signalId = strings.TrimPrefix(string(d.mid[0].upid), "BLACKOUT:")
+	// The VSS SignalId is present in the MID.
+	// SignalId is that UPID value in the MID which contains "BLACKOUT"
+	for i := 0; i < len(d.mid); i++ {
+		upidStr := string(d.mid[i].upid)
+		if strings.Contains(upidStr, "BLACKOUT") {
+			signalId = strings.TrimPrefix(upidStr, "BLACKOUT:")
+		}
 	}
 	return signalId
 }


### PR DESCRIPTION
We need to check delivery_not_restricted flag and whether the Upids 0x09 and 0x0E are present in the MID for it to be a license rotation signal.