### PR TITLE
scte35: fix cli segv on scte with SpliceNull commands

### DIFF
--- a/scte35/scte35.go
+++ b/scte35/scte35.go
@@ -103,6 +103,7 @@ func (s *scte35) parseTable(data []byte) error {
 			s.hasPTS = cmd.HasPTS()
 			s.commandInfo = cmd
 		case SpliceNull:
+			s.commandInfo = &spliceNull{}
 		default:
 			return gots.ErrSCTE35UnsupportedSpliceCommand
 		}

--- a/scte35/splicecommand.go
+++ b/scte35/splicecommand.go
@@ -61,6 +61,21 @@ func (c *timeSignal) PTS() gots.PTS {
 	return c.pts
 }
 
+type spliceNull struct {
+}
+
+func (c *spliceNull) CommandType() SpliceCommandType {
+	return SpliceNull
+}
+
+func (c *spliceNull) HasPTS() bool {
+	return false
+}
+
+func (c *spliceNull) PTS() gots.PTS {
+	return 0
+}
+
 type spliceInsert struct {
 	eventID               uint32
 	eventCancelIndicator  bool


### PR DESCRIPTION
Was seeing this using `cli -scte35`:

```
SCTE35 Message on PID 4416
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x10aef26]

goroutine 1 [running]:
main.printSpliceCommand(0x0, 0x0)
	/Users/tmm1/go/src/github.com/Comcast/gots/cli/parsefile.go:188 +0x26
main.printSCTE35(0xc420091140, 0x11006e0, 0xc420066180)
	/Users/tmm1/go/src/github.com/Comcast/gots/cli/parsefile.go:174 +0xc5
main.main()
	/Users/tmm1/go/src/github.com/Comcast/gots/cli/parsefile.go:135 +0x102d
```

After this patch:

```
SCTE35 Message on PID 4416
	Command Type SpliceNull
		Event ID 3221225472
		Type SegDescContentIdentification
SCTE35 Message on PID 4416
	Command Type SpliceNull
		Event ID 3221225472
		Type SegDescContentIdentification
```