### PR TITLE
psi: improve pmt descriptor tag detection

### DIFF
--- a/psi/doc.go
+++ b/psi/doc.go
@@ -41,7 +41,8 @@ const (
 
 // Program Element Stream Descriptor Type.
 const (
-	AUDIO_STREAM       uint8 = 2   // 0000 0010 (0x02)
+	VIDEO_STREAM       uint8 = 2   // 0000 0010 (0x02)
+	AUDIO_STREAM       uint8 = 3   // 0000 0011 (0x03)
 	REGISTRATION       uint8 = 5   // 0000 1000 (0x05)
 	CONDITIONAL_ACCESS uint8 = 9   // 0000 1001 (0x09)
 	LANGUAGE           uint8 = 10  // 0000 1010 (0x0A)
@@ -50,9 +51,10 @@ const (
 	COPYRIGHT          uint8 = 13  // 0000 1101 (0x0D)
 	MAXIMUM_BITRATE    uint8 = 14  // 0000 1110 (0x0E)
 	AVC_VIDEO          uint8 = 40  // 0010 1000 (0x28)
+	STREAM_IDENTIFIER  uint8 = 82  //           (0x52)
 	SCTE_ADAPTATION    uint8 = 151 // 1001 0111 (0x97)
 	EBP                uint8 = 233 // 1110 1001 (0xE9)
-	EC3                uint8 = 204 // 1100 1100(0xCC)
+	EC3                uint8 = 204 // 1100 1100 (0xCC)
 )
 
 // Unaccounted bytes before the end of the SectionLength field

--- a/psi/pmtdescriptor.go
+++ b/psi/pmtdescriptor.go
@@ -61,6 +61,8 @@ func (descriptor *pmtDescriptor) decode() string {
 			descriptor.DecodeIso639LanguageCode(), descriptor.DecodeIso639AudioType())
 	case MAXIMUM_BITRATE:
 		return fmt.Sprintf("Maximum Bit-Rate (%d)", descriptor.DecodeMaximumBitRate())
+	case VIDEO_STREAM:
+		return fmt.Sprintf("Video Stream (%d)", descriptor.tag)
 	case AUDIO_STREAM:
 		return fmt.Sprintf("Audio Stream (%d)", descriptor.tag)
 	case REGISTRATION:
@@ -79,6 +81,8 @@ func (descriptor *pmtDescriptor) decode() string {
 		return fmt.Sprintf("SCTE Adaptation (%d)", descriptor.tag)
 	case EBP:
 		return fmt.Sprintf("EBP (%d)", descriptor.tag)
+	case STREAM_IDENTIFIER:
+		return fmt.Sprintf("Stream Identifier (%d): %v", descriptor.tag, descriptor.data[0])
 	}
 	return "unknown tag (" + strconv.Itoa(int(descriptor.tag)) + ")"
 }


### PR DESCRIPTION
Fixes a serious bug where the video stream descriptor as being parsed as audio stream descriptor.