### PR TITLE
psi: expose StreamTypeDescription()

### DIFF
--- a/cli/parsefile.go
+++ b/cli/parsefile.go
@@ -226,7 +226,7 @@ func printPmt(pn uint16, pmt psi.PMT) {
 	printlnf("\tPIDs %v", pmt.Pids())
 	println("\tElementary Streams")
 	for _, es := range pmt.ElementaryStreams() {
-		printlnf("\t\tPid %v : StreamType %v", es.ElementaryPid(), es.StreamType())
+		printlnf("\t\tPid %v: StreamType %v: %v", es.ElementaryPid(), es.StreamType(), es.StreamTypeDescription())
 		for _, d := range es.Descriptors() {
 			printlnf("\t\t\t%+v", d)
 		}

--- a/psi/doc.go
+++ b/psi/doc.go
@@ -74,6 +74,7 @@ type PSI interface {
 // PmtStreamType is used to represent elementary steam type inside a PMT
 type PmtStreamType interface {
 	StreamType() uint8
+	StreamTypeDescription() string
 	IsStreamWherePresentationLagsEbp() bool
 	IsAudioContent() bool
 	IsVideoContent() bool

--- a/psi/pmt_test.go
+++ b/psi/pmt_test.go
@@ -47,6 +47,10 @@ func (es *testPmtElementaryStream) StreamType() uint8 {
 	return es.streamType
 }
 
+func (es *testPmtElementaryStream) StreamTypeDescription() string {
+	return "Test Stream Description"
+}
+
 func (es *testPmtElementaryStream) IsAudioContent() bool {
 	return es.presentationLagsEbp
 }


### PR DESCRIPTION
Makes cli more useful by printing out descriptors of the elementary stream types instead of just their ids