### PR TITLE
psi: ReadPMT skips over packets without a program map table

### DIFF
--- a/psi/pmt.go
+++ b/psi/pmt.go
@@ -355,6 +355,10 @@ func ReadPMT(r io.Reader, pid uint16) (PMT, error) {
 			if err != nil {
 				return nil, err
 			}
+			if len(pmt.Pids()) == 0 {
+				done = false
+				pmtAcc = packet.NewAccumulator(PmtAccumulatorDoneFunc)
+			}
 		}
 	}
 	return pmt, nil

--- a/psi/pmt_test.go
+++ b/psi/pmt_test.go
@@ -680,6 +680,7 @@ func TestReadPMTForSmoke(t *testing.T) {
 	pmt, err := ReadPMT(r, pid)
 	if err != nil {
 		t.Errorf("Unexpected error reading PMT: %v", err)
+		return
 	}
 	// sanity check (tests integration a bit)
 	if len(pmt.ElementaryStreams()) != 2 {
@@ -700,6 +701,34 @@ func TestReadPMTIncomplete(t *testing.T) {
 	_, err := ReadPMT(r, pid)
 	if err == nil {
 		t.Errorf("Expected to get error reading PMT, but did not")
+	}
+}
+
+func TestReadPMTSCTE(t *testing.T) {
+	bs, _ := hex.DecodeString("47403b1b00c0001500000100810000000000000100000000002f832c69ff" +
+		"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
+		"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
+		"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
+		"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
+		"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
+		"ffffffffffffffff47403b1c0002b0b20001cb0000f13df01809044749e1" +
+		"0b050441432d330504454143330504435545491bf13df0102a027e1f9700" +
+		"e9080c001f418507d04181f13ef00f810706380fff1f003f0a04656e6700" +
+		"81f13ff00f8107061003ff1f003f0a047370610086f140f00f8a01009700" +
+		"e9080c001f418507d041c0f141f012050445545631a100e9080c001f4185" +
+		"07d041c0f142f013050445545631a20100e9080c001f418507d041c0f164" +
+		"f008bf06496e766964690bcfa64bffff") // two PMT packets, first with SCTE 0xc0 table only
+	r := bytes.NewReader(bs)
+
+	pid := uint16(59)
+	pmt, err := ReadPMT(r, pid)
+	if err != nil {
+		t.Errorf("Unexpected error reading PMT: %v", err)
+		return
+	}
+	// sanity check (tests integration a bit)
+	if len(pmt.ElementaryStreams()) != 7 {
+		t.Errorf("PMT read is invalid, did not have expected number of streams")
 	}
 }
 


### PR DESCRIPTION
Following up on #75 

Some streams (ironically those I see coming from my comcast cable feed) can contain multiple tables on the PMT pid. These include cable-specific SCTE tables (0xc0), in addition to the usual PMT table (0x2).

Normally both tables are combined into one TS packet, but sometimes a single TS packet only contains the SCTE table. Then the following TS packet contains the PMT table.

This patch fixes `ReadPMT` to ignore packets that do not contain the PMT table, and to reset its state and keep reading until it actually finds a real PMT.