### PR TITLE
psi: handle multi-table PMT split across multiple packets

### DIFF
--- a/packet/accumulator.go
+++ b/packet/accumulator.go
@@ -69,7 +69,9 @@ func (a *accumulator) Add(pkt Packet) (bool, error) {
 		// First packet must have payload unit start indicator
 		return false, gots.ErrNoPayloadUnitStartIndicator
 	}
-	a.packets = append(a.packets, pkt)
+	pktCopy := make(Packet, PacketSize)
+	copy(pktCopy, pkt)
+	a.packets = append(a.packets, pktCopy)
 	b, err := a.Parse()
 	if err != nil {
 		return false, err

--- a/psi/pmt.go
+++ b/psi/pmt.go
@@ -47,9 +47,20 @@ type pmt struct {
 // PmtAccumulatorDoneFunc is a doneFunc that can be used for packet accumulation
 // to create a PMT
 func PmtAccumulatorDoneFunc(b []byte) (bool, error) {
-	if len(b) < (int(SectionLength(b)) + int(PointerField(b)) + int(PSIHeaderLen)) {
+	start := 1 + int(PointerField(b))
+	if len(b) < start {
 		return false, nil
 	}
+
+	sectionBytes := b[start:]
+	for len(sectionBytes) > 0 && sectionBytes[0] != 0xFF {
+		tableLength := sectionLength(sectionBytes)
+		if len(sectionBytes) < int(tableLength)+3 {
+			return false, nil
+		}
+		sectionBytes = sectionBytes[3+tableLength:]
+	}
+
 	return true, nil
 }
 

--- a/psi/pmt_test.go
+++ b/psi/pmt_test.go
@@ -132,6 +132,7 @@ func TestParseMultipleTables(t *testing.T) {
 		}
 	}
 }
+
 func TestBuildPMT(t *testing.T) {
 	pkt, _ := hex.DecodeString("474064100002b02d0001cb0000e065f0060504435545491b" +
 		"e065f0050e030004b00fe066f0060a04656e670086e06ef0" +
@@ -727,6 +728,36 @@ func TestReadPMTSCTE(t *testing.T) {
 		return
 	}
 	// sanity check (tests integration a bit)
+	if len(pmt.ElementaryStreams()) != 7 {
+		t.Errorf("PMT read is invalid, did not have expected number of streams")
+	}
+}
+
+func TestReadPMT_MultipleTables_MultiplePackets(t *testing.T) {
+	bs, _ := hex.DecodeString("47403b1e00c0001500000100610000000000000100000000" +
+		"0035e3e2d702b0b20001c50000eefdf01809044749e10b05" +
+		"0441432d330504454143330504435545491beefdf0102a02" +
+		"7e1f9700e9080c001f418507d04181eefef00f810706380f" +
+		"ff1f003f0a04656e670081eefff00f8107061003ff1f003f" +
+		"0a047370610086ef00f00f8a01009700e9080c001f418507" +
+		"d041c0ef01f012050445545631a100e9080c001f418507d0" +
+		"41c0ef02f013050445545631a20100e9080c001f47003b1f" +
+		"418507d041c0ef03f008bf06496e76696469a5cff3afffff" +
+		"ffffffffffffffffffffffffffffffffffffffffffffffff" +
+		"ffffffffffffffffffffffffffffffffffffffffffffffff" +
+		"ffffffffffffffffffffffffffffffffffffffffffffffff" +
+		"ffffffffffffffffffffffffffffffffffffffffffffffff" +
+		"ffffffffffffffffffffffffffffffffffffffffffffffff" +
+		"ffffffffffffffffffffffffffffffffffffffffffffffff" +
+		"ffffffffffffffffffffffffffffffff") // two tables (0xc0 and 0x2) combined across two packets
+	r := bytes.NewReader(bs)
+
+	pid := uint16(59)
+	pmt, err := ReadPMT(r, pid)
+	if err != nil {
+		t.Errorf("Unexpected error reading PMT: %v", err)
+		return
+	}
 	if len(pmt.ElementaryStreams()) != 7 {
 		t.Errorf("PMT read is invalid, did not have expected number of streams")
 	}


### PR DESCRIPTION
Following up on #75 and #85, which both dealt with cases where multiple tables exist in the PMT stream (SCTE 0xc0 table as well as 0x2 program map table).

This time, the 0xc0 and 0x2 tables are again combined (like with #75), however now the combined size is larger than a single packet so the payload has to be continued into a second packet.

I added a test case, and fixed the PMTDoneFunc implementation, however the new test is still not passing. It looks like I've uncovered some sort of bug in the accumulator. When I observe the the values of the packets in `accumulator.Parse()`, both entries have the same contents. Somehow the contents of the first packet are being lost between the first and second invocations of the doneFunc.

cc @kortschak since he was looking at the accumulator recently as well 