### PR TITLE
Packet switch to receivers, packet modification

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -27,14 +27,22 @@ package gots
 import "errors"
 
 var (
+	// ErrBadSyncByte is returned when the sync byte (first byte of packet) is not valid
+	ErrBadSyncByte = errors.New("sync byte is not valid")
 	// ErrUnrecognizedEbpType is returned if the EBP cannot be parsed
 	ErrUnrecognizedEbpType = errors.New("unrecognized EBP")
 	// ErrNoEBP is returned when an attempt is made to extract an EBP from a packet that does not contain one
 	ErrNoEBP = errors.New("packet does not contain EBP")
 	// ErrInvalidPacketLength denotes an packet length that is not packet.PacketSize bytes in length
 	ErrInvalidPacketLength = errors.New("invalid packet length")
+	// ErrInvalidTSCFlag is returned when the transport scrambling control bit is set to the bit reserved by the specification
+	ErrInvalidTSCFlag = errors.New("invalid transport scrambling control option.")
+	// ErrInvalidAFCFlag is returned when the adaptation field control bits dont have a payload or an adaptation field
+	ErrInvalidAFCFlag = errors.New("invalid packet length")
 	// ErrNoPayload denotes that the attempted operation is not valid on a packet with no payload
 	ErrNoPayload = errors.New("packet does not contain payload")
+	// ErrNoAdaptationField is returned if the adaptation field cannot be accessed or does not exist.
+	ErrNoAdaptationField = errors.New("packet does not contain an adaptation field")
 	// ErrNoPrivateTransportData is returned when an attempt is made to access private transport data when none exists
 	ErrNoPrivateTransportData = errors.New("adaptation field has no private transport data")
 	// ErrNoSplicePoint is returned when an attempt to access a splice countdown and no splice point exists

--- a/errors.go
+++ b/errors.go
@@ -43,6 +43,12 @@ var (
 	ErrNoPayload = errors.New("packet does not contain payload")
 	// ErrNoAdaptationField is returned if the adaptation field cannot be accessed or does not exist.
 	ErrNoAdaptationField = errors.New("packet does not contain an adaptation field")
+	// ErrAdaptationFieldTooLarge is returned if the adaptation field is too large to be put in a packet.
+	ErrAdaptationFieldTooLarge = errors.New("adaptation field is too large and cannot shrink")
+	// ErrAdaptationFieldCannotGrow is returned if the adaptation field will overwrite the payload if it grows.
+	ErrAdaptationFieldCannotGrow = errors.New("adaptation field cannot cannot grow beyond its allocated length")
+	// ErrAdaptationFieldZeroLength is returned if the adaptation field is empty and only used for stuffing.
+	ErrAdaptationFieldZeroLength = errors.New("adaptation field is empty")
 	// ErrNoPrivateTransportData is returned when an attempt is made to access private transport data when none exists
 	ErrNoPrivateTransportData = errors.New("adaptation field has no private transport data")
 	// ErrNoSplicePoint is returned when an attempt to access a splice countdown and no splice point exists

--- a/errors.go
+++ b/errors.go
@@ -51,6 +51,9 @@ var (
 	ErrNoPCR = errors.New("adaptation field has no Program Clock Reference")
 	// ErrNoOPCR is returned when an attempt is made to access an adaptation field OPCR that does not exist
 	ErrNoOPCR = errors.New("adaptation field has no Original Program Clock Reference")
+	// ErrNoAdaptationFieldExtension is returned when an attempt is made to access adaptation field's
+	// Adaptation Field Extension when it does not exist
+	ErrNoAdaptationFieldExtension = errors.New("adaptation field has no Adaptation Field Extension")
 	// ErrPATNotFound is returned when expected PAT packet is not found when
 	// reading TS packets.
 	ErrPATNotFound = errors.New("No PAT was found while reading TS")

--- a/packet/adaptationfield.go
+++ b/packet/adaptationfield.go
@@ -14,7 +14,7 @@ func (af AdaptationField) invalid() bool {
 	// exist in order to be modified.
 
 	// order matters, short circuit
-	return len(af) != PacketSize || !Packet(af).HasAdaptationField()
+	return len(af) != PacketSize // || !Packet(af).HasAdaptationField()
 }
 
 // initAdaptationField initializes the adaptation field to have all false flags
@@ -30,10 +30,7 @@ func initAdaptationField(p Packet) {
 // parseAdaptationField parses the adaptation field that is present in a packet.
 // no need to report errors since this is handled during packet creation.
 func parseAdaptationField(p Packet) AdaptationField {
-	if p.HasAdaptationField() { // nil packet does not have an adaptation field
-		return AdaptationField(p)
-	}
-	return nil
+	return AdaptationField(p)
 }
 
 // pcrLength returns the length of the PCR, if there is no PCR then its length is zero

--- a/packet/adaptationfield.go
+++ b/packet/adaptationfield.go
@@ -64,13 +64,13 @@ func (af AdaptationField) getBit(index int, mask byte) bool {
 // 0 is returned if the bit is unchanged.
 // this can be used to find if a field is growing or shrinking.
 func (af AdaptationField) bitDelta(index int, mask byte, value bool) int {
-	if value != af.getBit(index, mask) {
-		if value {
-			return 1 // growing
-		}
-		return -1 // shrinking
+	if value == af.getBit(index, mask) {
+		return 0 // same
 	}
-	return 0 // same
+	if value {
+		return 1 // growing
+	}
+	return -1 // shrinking
 }
 
 // valid returns any errors that prevent the AdaptationField from being valid.
@@ -171,12 +171,12 @@ func (af AdaptationField) spliceCountdownStart() int {
 // transportPrivateDataLength returns the length of the transport private data,
 // if there is no transport private data then its length is zero.
 func (af AdaptationField) transportPrivateDataLength() int {
-	if af.hasTransportPrivateData() {
-		// cannot extend beyond adaptation field, number of bytes
-		// for field stored in transportPrivateDataLength
-		return 1 + int(af[af.transportPrivateDataStart()])
+	if !af.hasTransportPrivateData() {
+		return 0
 	}
-	return 0
+	// cannot extend beyond adaptation field, number of bytes
+	// for field stored in transportPrivateDataLength
+	return 1 + int(af[af.transportPrivateDataStart()])
 }
 
 // transportPrivateDataStart returns the start index of where the
@@ -188,10 +188,10 @@ func (af AdaptationField) transportPrivateDataStart() int {
 // adaptationExtensionLength returns the length of the adaptation field extension,
 // if there is no adaptation field extension then its length is zero
 func (af AdaptationField) adaptationExtensionLength() int {
-	if af.hasAdaptationFieldExtension() {
-		return 1 + int(af[af.adaptationExtensionStart()])
+	if !af.hasAdaptationFieldExtension() {
+		return 0
 	}
-	return 0
+	return 1 + int(af[af.adaptationExtensionStart()])
 }
 
 // adaptationExtensionStart returns the start index of where the

--- a/packet/adaptationfield.go
+++ b/packet/adaptationfield.go
@@ -1,3 +1,27 @@
+/*
+MIT License
+
+Copyright 2016 Comcast Cable Communications Management, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 package packet
 
 import (

--- a/packet/adaptationfield.go
+++ b/packet/adaptationfield.go
@@ -1,0 +1,258 @@
+package packet
+
+import (
+	"fmt"
+)
+
+type AdaptationField []byte
+
+func (af AdaptationField) invalid() bool {
+	// order matters, short circuit
+	return len(af) != PacketSize || !Packet(af).HasAdaptationField()
+}
+
+// all false flags
+func initAdaptationField(p Packet) {
+	af := AdaptationField(p)
+	af[4] = 1
+	af[5] = 0x00 // no flags are set by default
+}
+
+func parseAdaptationField(p Packet) AdaptationField {
+	if p.HasAdaptationField() { // nil packet does not have an adaptation field
+		return AdaptationField(p)
+	}
+	return nil
+}
+
+func (af AdaptationField) pcrLength() int {
+	if af.HasPCR() {
+		return 6
+	}
+	return 0
+}
+
+func (af AdaptationField) opcrLength() int {
+	if af.HasOPCR() {
+		return 6
+	}
+	return 0
+}
+
+func (af AdaptationField) spliceCountdownLength() int {
+	if af.HasSplicingPoint() {
+		return 1
+	}
+	return 0
+}
+
+func (af AdaptationField) transportPrivateDataLength() int {
+	if af.HasTransportPrivateData() {
+		indexLength := 6 +
+			af.pcrLength() +
+			af.opcrLength() +
+			af.spliceCountdownLength()
+		return 1 + int(af[indexLength])
+	}
+	return 0
+}
+
+func (af AdaptationField) adaptationExtensionLength() int {
+	if af.HasAdaptationFieldExtension() {
+		// TODO: make new type and call its methods to find the length
+		return 1
+	}
+	return 0
+}
+
+func (af AdaptationField) calculateMinLength() int {
+	if af.invalid() {
+		return 0
+	}
+	return 6 +
+		af.pcrLength() + af.opcrLength() + af.spliceCountdownLength() +
+		af.transportPrivateDataLength() + af.adaptationExtensionLength()
+}
+
+func (af AdaptationField) setBit(index int, mask byte, value bool) {
+	if af.invalid() {
+		return
+	}
+	if value {
+		af[index] = af[index] | mask
+	} else {
+		af[index] = af[index] & ^mask
+	}
+}
+
+func (af AdaptationField) getBit(index int, mask byte) bool {
+	if af.invalid() {
+		return false
+	}
+	return af[index]&mask != 0
+}
+
+func (af AdaptationField) setBitReturnDelta(index int, mask byte, value bool) int {
+	if af.invalid() {
+		return 0
+	}
+	oldValue := af.getBit(index, mask)
+	af.setBit(index, mask, value)
+	if value != oldValue {
+		if value {
+			return 1 // growing
+		}
+		return -1 // shrinking
+	}
+	return 0 // same
+}
+
+func (af AdaptationField) setLength(length int) {
+	if af.invalid() {
+		return
+	}
+	af[4] = byte(length)
+}
+
+func (af AdaptationField) resizeAF(start int, delta int) {
+	if delta > 0 { // growing
+		// move existing bytes to new location
+		payloadStart := af.calculateMinLength()
+		endNew := payloadStart - 1
+		end := endNew - delta
+		for start <= end {
+			af[endNew] = af[end]
+			endNew--
+			end--
+		}
+		packetEnd := len(af) - 1
+		if af.Length() < payloadStart-5 {
+			// erase payload
+			for payloadStart <= packetEnd {
+				af[payloadStart] = 0xFF
+				payloadStart++
+			}
+			af.setLength(183)
+		}
+	}
+	if delta < 0 { // shrinking
+		end := af.calculateMinLength() - delta
+		startNew := start
+		start := startNew - delta
+		for start <= end {
+			af[startNew] = af[start]
+			startNew++
+			start++
+		}
+		//preserve payload size and stuff it
+		for startNew <= end {
+			af[startNew] = 0xFF
+			startNew++
+		}
+	}
+}
+
+// Length returns the length of the adaptation field
+func (af AdaptationField) Length() int {
+	if af.invalid() {
+		return 0
+	}
+	return int(af[4])
+}
+
+// SetDiscontinuity sets the Discontinuity field of the packet
+func (af AdaptationField) SetDiscontinuity(value bool) {
+	af.setBit(5, 0x80, value)
+}
+
+// Discontinuity returns the value of the discontinuity field in the packet
+func (af AdaptationField) Discontinuity() bool {
+	return af.getBit(5, 0x80)
+}
+
+func (af AdaptationField) SetRandomAccess(value bool) {
+	af.setBit(5, 0x40, value)
+}
+
+func (af AdaptationField) RandomAccess() bool {
+	return af.getBit(5, 0x40)
+}
+
+func (af AdaptationField) SetESPriority(value bool) {
+	af.setBit(5, 0x20, value)
+}
+
+func (af AdaptationField) ESPriority() bool {
+	return af.getBit(5, 0x20)
+}
+
+func (af AdaptationField) SetHasPCR(value bool) {
+	delta := 6 * af.setBitReturnDelta(5, 0x10, value)
+	af.resizeAF(6, delta)
+}
+
+func (af AdaptationField) HasPCR() bool {
+	return af.getBit(5, 0x10)
+}
+
+func (af AdaptationField) SetHasOPCR(value bool) {
+	delta := 6 * af.setBitReturnDelta(5, 0x08, value)
+	af.resizeAF(6+
+		af.pcrLength(),
+		delta,
+	)
+}
+
+func (af AdaptationField) HasOPCR() bool {
+	return af.getBit(5, 0x08)
+}
+
+func (af AdaptationField) SetHasSplicingPoint(value bool) {
+	delta := 1 * af.setBitReturnDelta(5, 0x04, value)
+	af.resizeAF(6+
+		af.pcrLength()+
+		af.opcrLength(),
+		delta,
+	)
+}
+
+func (af AdaptationField) HasSplicingPoint() bool {
+	return af.getBit(5, 0x04)
+}
+
+func (af AdaptationField) SetHasTransportPrivateData(value bool) {
+	delta := 1 * af.setBitReturnDelta(5, 0x02, value)
+	// TODO: craft a TP
+	af.resizeAF(6+
+		af.pcrLength()+
+		af.opcrLength()+
+		af.spliceCountdownLength(),
+		delta,
+	)
+}
+
+func (af AdaptationField) HasTransportPrivateData() bool {
+	return af.getBit(5, 0x02)
+}
+
+func (af AdaptationField) SetHasAdaptationFieldExtension(value bool) {
+	delta := af.setBitReturnDelta(5, 0x01, value) * 1
+	af.resizeAF(6+
+		af.pcrLength()+
+		af.opcrLength()+
+		af.spliceCountdownLength()+
+		af.transportPrivateDataLength(),
+		delta,
+	)
+}
+
+func (af AdaptationField) HasAdaptationFieldExtension() bool {
+	return af.getBit(5, 0x01)
+}
+
+func (af AdaptationField) String() string {
+	if af.invalid() {
+		return "Null"
+	}
+	return fmt.Sprintf("%X", []byte(af[4:]))
+}

--- a/packet/adaptationfield.go
+++ b/packet/adaptationfield.go
@@ -5,16 +5,16 @@ import (
 	"github.com/Comcast/gots"
 )
 
-// invalid returns true if the size of the slice (AdaptationField) is invalid,
-// or the adaptation field doesnt exist
-func (af AdaptationField) invalid() bool {
-	// exact size of an adaptation field slice to work correctly
-	// this is not related to the Field "Length" in the adaptation field
-	// it is the same as the length of a packet. the adaptation must also
-	// exist in order to be modified.
-
-	// order matters, short circuit
-	return len(af) != PacketSize // || !Packet(af).HasAdaptationField()
+// valid returns true if the length of the packet slice is
+// anything but PacketSize (188)
+func (af AdaptationField) valid() error {
+	if len(af) != PacketSize {
+		return gots.ErrInvalidPacketLength
+	}
+	if hasAF, _ := Packet(af).HasAdaptationField(); !hasAF {
+		return gots.ErrNoAdaptationField
+	}
+	return nil
 }
 
 // initAdaptationField initializes the adaptation field to have all false flags
@@ -33,9 +33,28 @@ func parseAdaptationField(p Packet) AdaptationField {
 	return AdaptationField(p)
 }
 
+func (af AdaptationField) hasPCR() bool {
+	return af.getBit(5, 0x10)
+}
+func (af AdaptationField) hasOPCR() bool {
+	return af.getBit(5, 0x08)
+}
+
+func (af AdaptationField) hasSplicingPoint() bool {
+	return af.getBit(5, 0x04)
+}
+
+func (af AdaptationField) hasTransportPrivateData() bool {
+	return af.getBit(5, 0x02)
+}
+
+func (af AdaptationField) hasAdaptationFieldExtension() bool {
+	return af.getBit(5, 0x01)
+}
+
 // pcrLength returns the length of the PCR, if there is no PCR then its length is zero
 func (af AdaptationField) pcrLength() int {
-	if af.HasPCR() {
+	if af.hasPCR() {
 		return 6
 	}
 	return 0
@@ -45,7 +64,7 @@ const pcrStart = 6
 
 // opcrLength returns the length of the OPCR, if there is no OPCR then its length is zero
 func (af AdaptationField) opcrLength() int {
-	if af.HasOPCR() {
+	if af.hasOPCR() {
 		return 6
 	}
 	return 0
@@ -58,7 +77,7 @@ func (af AdaptationField) opcrStart() int {
 
 // spliceCountdownLength returns the length of the splice countdown, if there is no splice countdown then its length is zero
 func (af AdaptationField) spliceCountdownLength() int {
-	if af.HasSplicingPoint() {
+	if af.hasSplicingPoint() {
 		return 1
 	}
 	return 0
@@ -72,7 +91,7 @@ func (af AdaptationField) spliceCountdownStart() int {
 // transportPrivateDataLength returns the length of the transport private data,
 // if there is no transport private data then its length is zero
 func (af AdaptationField) transportPrivateDataLength() int {
-	if af.HasTransportPrivateData() {
+	if af.hasTransportPrivateData() {
 		// cannot extend beyond adaptation field, number of bytes
 		// for field stored in transportPrivateDataLength
 		return 1 + int(af[af.transportPrivateDataStart()])
@@ -88,7 +107,7 @@ func (af AdaptationField) transportPrivateDataStart() int {
 // adaptationExtensionLength returns the length of the adaptation field extension,
 //  if there is no adaptation field extension then its length is zero
 func (af AdaptationField) adaptationExtensionLength() int {
-	if af.HasAdaptationFieldExtension() {
+	if af.hasAdaptationFieldExtension() {
 		return 1 + int(af[af.adaptationExtensionStart()])
 	}
 	return 0
@@ -103,16 +122,18 @@ func (af AdaptationField) adaptationExtensionStart() int {
 
 // calculates the length of the Adaptation Field
 // (with respect to the start of the packet) excluding stuffing
-func (af AdaptationField) calculateMinLength() int {
+func (af AdaptationField) stuffingStart() int {
 	return pcrStart +
 		af.pcrLength() + af.opcrLength() + af.spliceCountdownLength() +
 		af.transportPrivateDataLength() + af.adaptationExtensionLength()
 }
 
+// length returns the length of the adaptation field
+func (af AdaptationField) stuffingEnd() int {
+	return int(af[4]) + 5
+}
+
 func (af AdaptationField) setBit(index int, mask byte, value bool) {
-	if af.invalid() {
-		return
-	}
 	if value {
 		af[index] |= mask
 	} else {
@@ -121,15 +142,11 @@ func (af AdaptationField) setBit(index int, mask byte, value bool) {
 }
 
 func (af AdaptationField) getBit(index int, mask byte) bool {
-	if af.invalid() {
-		return false
-	}
 	return af[index]&mask != 0
 }
 
 func (af AdaptationField) bitDelta(index int, mask byte, value bool) int {
-	oldValue := af.getBit(index, mask)
-	if value != oldValue {
+	if value != af.getBit(index, mask) {
 		if value {
 			return 1 // growing
 		}
@@ -139,21 +156,24 @@ func (af AdaptationField) bitDelta(index int, mask byte, value bool) int {
 }
 
 func (af AdaptationField) setLength(length int) {
-	if af.invalid() {
-		return
-	}
 	af[4] = byte(length)
+}
+
+func (af AdaptationField) stuffAF() {
+	for i := af.stuffingStart(); i < af.stuffingEnd(); i++ {
+		af[i] = 0xFF // stuffing byte must be 0xFF
+	}
 }
 
 func (af AdaptationField) resizeAF(start int, delta int) {
 	if delta > 0 { // shifting for growing
-		end := af.calculateMinLength()
+		end := af.stuffingStart()
 		startRight := start + delta
-		endRight := af.calculateMinLength() + delta
+		endRight := af.stuffingStart() + delta
 		src := af[start:end]
 		dst := af[startRight:endRight]
 		copy(dst, src)
-		if af.Length() < endRight-5 {
+		if af.stuffingEnd() < endRight {
 			// erase payload, it is corrupt anyways
 			for i := endRight; i < len(af); i++ {
 				af[i] = 0xFF // packet is stuffed until the very end.
@@ -166,7 +186,7 @@ func (af AdaptationField) resizeAF(start int, delta int) {
 	}
 	if delta < 0 {
 		startRight := start - delta
-		endRight := af.calculateMinLength()
+		endRight := af.stuffingStart()
 		end := endRight + delta
 		src := []byte(af[startRight:endRight])
 		dst := []byte(af[start:end])
@@ -178,161 +198,252 @@ func (af AdaptationField) resizeAF(start int, delta int) {
 }
 
 // Length returns the length of the adaptation field
-func (af AdaptationField) Length() int {
-	if af.invalid() {
-		return 0
+func (af AdaptationField) Length() (int, error) {
+	if err := af.valid(); err != nil {
+		return 0, err
 	}
-	return int(af[4])
+	return int(af[4]), nil
 }
 
 // SetDiscontinuity sets the Discontinuity field of the packet
-func (af AdaptationField) SetDiscontinuity(value bool) {
+func (af AdaptationField) SetDiscontinuity(value bool) error {
+	if err := af.valid(); err != nil {
+		return err
+	}
 	af.setBit(5, 0x80, value)
+	return nil
 }
 
 // Discontinuity returns the value of the discontinuity field in the packet
-func (af AdaptationField) Discontinuity() bool {
-	return af.getBit(5, 0x80)
+func (af AdaptationField) Discontinuity() (bool, error) {
+	if err := af.valid(); err != nil {
+		return false, err
+	}
+	return af.getBit(5, 0x80), nil
 }
 
-func (af AdaptationField) SetRandomAccess(value bool) {
+func (af AdaptationField) SetRandomAccess(value bool) error {
+	if err := af.valid(); err != nil {
+		return err
+	}
 	af.setBit(5, 0x40, value)
+	return nil
 }
 
-func (af AdaptationField) RandomAccess() bool {
-	return af.getBit(5, 0x40)
+func (af AdaptationField) RandomAccess() (bool, error) {
+	if err := af.valid(); err != nil {
+		return false, err
+	}
+	return af.getBit(5, 0x40), nil
 }
 
-func (af AdaptationField) SetESPriority(value bool) {
+func (af AdaptationField) SetESPriority(value bool) error {
+	if err := af.valid(); err != nil {
+		return err
+	}
 	af.setBit(5, 0x20, value)
+	return nil
 }
 
-func (af AdaptationField) ESPriority() bool {
-	return af.getBit(5, 0x20)
+func (af AdaptationField) ESPriority() (bool, error) {
+	if err := af.valid(); err != nil {
+		return false, err
+	}
+	return af.getBit(5, 0x20), nil
 }
 
-func (af AdaptationField) SetHasPCR(value bool) {
+func (af AdaptationField) SetHasPCR(value bool) error {
+	if err := af.valid(); err != nil {
+		return err
+	}
 	delta := 6 * af.bitDelta(5, 0x10, value)
 	af.resizeAF(pcrStart, delta)
 	af.setBit(5, 0x10, value)
+	return nil
 }
 
-func (af AdaptationField) HasPCR() bool {
-	return af.getBit(5, 0x10)
+func (af AdaptationField) HasPCR() (bool, error) {
+	if err := af.valid(); err != nil {
+		return false, err
+	}
+	return af.hasPCR(), nil
 }
 
-func (af AdaptationField) SetPCR(PCR uint64) {
-	if !af.HasPCR() {
-		return
+func (af AdaptationField) SetPCR(PCR uint64) error {
+	if err := af.valid(); err != nil {
+		return err
+	}
+	if !af.hasPCR() {
+		return gots.ErrNoPCR
 	}
 	gots.InsertPCR(af[pcrStart:af.opcrStart()], PCR)
+	return nil
 }
 
-func (af AdaptationField) PCR() uint64 {
-	if !af.HasPCR() {
-		return 0
+func (af AdaptationField) PCR() (uint64, error) {
+	if err := af.valid(); err != nil {
+		return 0, err
 	}
-	return gots.ExtractPCR(af[pcrStart:af.opcrStart()])
+	if !af.hasPCR() {
+		return 0, gots.ErrNoPCR
+	}
+	return gots.ExtractPCR(af[pcrStart:af.opcrStart()]), nil
 }
 
-func (af AdaptationField) SetHasOPCR(value bool) {
+func (af AdaptationField) SetHasOPCR(value bool) error {
+	if err := af.valid(); err != nil {
+		return err
+	}
 	delta := 6 * af.bitDelta(5, 0x08, value)
 	af.resizeAF(af.opcrStart(), delta)
 	af.setBit(5, 0x08, value)
+	return nil
 }
 
-func (af AdaptationField) HasOPCR() bool {
-	return af.getBit(5, 0x08)
+func (af AdaptationField) HasOPCR() (bool, error) {
+	if err := af.valid(); err != nil {
+		return false, err
+	}
+	return af.hasOPCR(), nil
 }
 
-func (af AdaptationField) SetOPCR(PCR uint64) {
-	if !af.HasOPCR() {
-		return
+func (af AdaptationField) SetOPCR(PCR uint64) error {
+	if err := af.valid(); err != nil {
+		return err
+	}
+	if !af.hasOPCR() {
+		return gots.ErrNoOPCR
 	}
 	gots.InsertPCR(af[af.opcrStart():af.spliceCountdownStart()], PCR)
+	return nil
 }
 
-func (af AdaptationField) OPCR() uint64 {
-	if !af.HasOPCR() {
-		return 0
+func (af AdaptationField) OPCR() (uint64, error) {
+	if err := af.valid(); err != nil {
+		return 0, err
 	}
-	return gots.ExtractPCR(af[af.opcrStart():af.spliceCountdownStart()])
+	if !af.hasOPCR() {
+		return 0, gots.ErrNoOPCR
+	}
+	return gots.ExtractPCR(af[af.opcrStart():af.spliceCountdownStart()]), nil
 }
 
-func (af AdaptationField) SetHasSplicingPoint(value bool) {
+func (af AdaptationField) SetHasSplicingPoint(value bool) error {
+	if err := af.valid(); err != nil {
+		return err
+	}
 	delta := 1 * af.bitDelta(5, 0x04, value)
 	af.resizeAF(af.spliceCountdownStart(), delta)
 	af.setBit(5, 0x04, value)
+	return nil
 }
 
-func (af AdaptationField) HasSplicingPoint() bool {
-	return af.getBit(5, 0x04)
+func (af AdaptationField) HasSplicingPoint() (bool, error) {
+	if err := af.valid(); err != nil {
+		return false, err
+	}
+	return af.hasSplicingPoint(), nil
 }
 
-func (af AdaptationField) SetSpliceCountdown(value int) {
-	if !af.HasSplicingPoint() {
-		return
+func (af AdaptationField) SetSpliceCountdown(value int) error {
+	if err := af.valid(); err != nil {
+		return err
+	}
+	if !af.hasSplicingPoint() {
+		return gots.ErrNoSplicePoint
 	}
 	af[af.spliceCountdownStart()] = byte(value)
+	return nil
 }
 
-func (af AdaptationField) SpliceCountdown() int {
-	if !af.HasSplicingPoint() {
-		return 0
+func (af AdaptationField) SpliceCountdown() (int, error) {
+	if err := af.valid(); err != nil {
+		return 0, err
 	}
-	return int(int8(af[af.spliceCountdownStart()])) // int8 cast is for 2s complement numbers
+	if !af.hasSplicingPoint() {
+		return 0, gots.ErrNoSplicePoint
+	}
+	return int(int8(af[af.spliceCountdownStart()])), nil // int8 cast is for 2s complement numbers
 }
 
-func (af AdaptationField) SetHasTransportPrivateData(value bool) {
+func (af AdaptationField) SetHasTransportPrivateData(value bool) error {
+	if err := af.valid(); err != nil {
+		return err
+	}
 	delta := 1 * af.bitDelta(5, 0x02, value)
 	af.resizeAF(af.transportPrivateDataStart(), delta)
 	af[af.transportPrivateDataStart()] = 0 // zero length by default
 	af.setBit(5, 0x02, value)
+	return nil
 }
 
-func (af AdaptationField) HasTransportPrivateData() bool {
-	return af.getBit(5, 0x02)
+func (af AdaptationField) HasTransportPrivateData() (bool, error) {
+	if err := af.valid(); err != nil {
+		return false, err
+	}
+	return af.hasTransportPrivateData(), nil
 }
 
-func (af AdaptationField) SetTransportPrivateData(data []byte) {
+func (af AdaptationField) SetTransportPrivateData(data []byte) error {
+	if err := af.valid(); err != nil {
+		return err
+	}
+	if !af.hasTransportPrivateData() {
+		return gots.ErrNoPrivateTransportData
+	}
 	delta := len(data) - (af.transportPrivateDataLength() - 1)
 	start := af.transportPrivateDataStart() + 1
 	end := start + len(data)
 	af.resizeAF(start, delta)
 	copy(af[start:end], data)
 	af[start-1] = byte(len(data))
+	return nil
 }
 
 func (af AdaptationField) TransportPrivateData() []byte {
 	return af[af.transportPrivateDataStart():af.adaptationExtensionStart()]
 }
 
-func (af AdaptationField) SetHasAdaptationFieldExtension(value bool) {
+func (af AdaptationField) SetHasAdaptationFieldExtension(value bool) error {
+	if err := af.valid(); err != nil {
+		return err
+	}
 	delta := 1 * af.bitDelta(5, 0x01, value)
 	af.resizeAF(af.adaptationExtensionStart(), delta)
 	af[af.adaptationExtensionStart()] = 0
 	af.setBit(5, 0x01, value)
+	return nil
 }
 
-func (af AdaptationField) HasAdaptationFieldExtension() bool {
-	return af.getBit(5, 0x01)
+func (af AdaptationField) HasAdaptationFieldExtension() (bool, error) {
+	if err := af.valid(); err != nil {
+		return false, err
+	}
+	return af.hasAdaptationFieldExtension(), nil
 }
 
-func (af AdaptationField) SetAdaptationFieldExtension(data []byte) {
+func (af AdaptationField) SetAdaptationFieldExtension(data []byte) error {
+	if err := af.valid(); err != nil {
+		return err
+	}
+	if !af.hasAdaptationFieldExtension() {
+		return gots.ErrNoAdaptationFieldExtension
+	}
 	delta := len(data) - (af.adaptationExtensionLength() - 1)
 	start := af.adaptationExtensionStart() + 1
 	end := start + len(data)
 	af.resizeAF(start, delta)
 	copy(af[start:end], data)
 	af[start-1] = byte(len(data))
+	return nil
 }
 
 func (af AdaptationField) AdaptationFieldExtension() []byte {
-	return af[af.adaptationExtensionStart():af.calculateMinLength()]
+	return af[af.adaptationExtensionStart():af.stuffingStart()]
 }
 
 func (af AdaptationField) String() string {
-	if af.invalid() {
+	if af.valid() != nil {
 		return "Null"
 	}
 	return fmt.Sprintf("%X", []byte(af[4:]))

--- a/packet/adaptationfield.go
+++ b/packet/adaptationfield.go
@@ -6,18 +6,27 @@ import (
 
 type AdaptationField []byte
 
+// invalid returns true if the size of the slice (AdaptationField) is invalid,
+// or the adaptation field doesnt exist
 func (af AdaptationField) invalid() bool {
+	// exact size of an adaptation field slice to work correctly
+	// this is not related to the Field "Length" in the adaptation field
+	// it is the same as the length of a packet. the adaptation must also
+	// exist in order to be modified.
+
 	// order matters, short circuit
 	return len(af) != PacketSize || !Packet(af).HasAdaptationField()
 }
 
-// all false flags
+// initAdaptationField initializes the adaptation field to have all false flags
 func initAdaptationField(p Packet) {
 	af := AdaptationField(p)
-	af[4] = 1
+	af[4] = 1    // size of empty adaptation field is at least 1, zero size is used only for stuffing
 	af[5] = 0x00 // no flags are set by default
 }
 
+// parseAdaptationField parses the adaptation field that is present in a packet.
+// no need to report errors since this is handled during packet creation.
 func parseAdaptationField(p Packet) AdaptationField {
 	if p.HasAdaptationField() { // nil packet does not have an adaptation field
 		return AdaptationField(p)
@@ -25,6 +34,7 @@ func parseAdaptationField(p Packet) AdaptationField {
 	return nil
 }
 
+// returns the length of the PCR, if there is no PCR then its length is zero
 func (af AdaptationField) pcrLength() int {
 	if af.HasPCR() {
 		return 6
@@ -32,6 +42,7 @@ func (af AdaptationField) pcrLength() int {
 	return 0
 }
 
+// returns the length of the OPCR, if there is no PCR then its length is zero
 func (af AdaptationField) opcrLength() int {
 	if af.HasOPCR() {
 		return 6
@@ -39,6 +50,7 @@ func (af AdaptationField) opcrLength() int {
 	return 0
 }
 
+// returns the length of the splice countdown, if there is no splice countdown then its length is zero
 func (af AdaptationField) spliceCountdownLength() int {
 	if af.HasSplicingPoint() {
 		return 1
@@ -46,8 +58,11 @@ func (af AdaptationField) spliceCountdownLength() int {
 	return 0
 }
 
+// returns the length of the transport private data, if there is no transport private data then its length is zero
 func (af AdaptationField) transportPrivateDataLength() int {
 	if af.HasTransportPrivateData() {
+		// cannot extend beyond adaptation field, number of bytes
+		// for field stored in transportPrivateDataLength
 		indexLength := 6 +
 			af.pcrLength() +
 			af.opcrLength() +
@@ -57,6 +72,7 @@ func (af AdaptationField) transportPrivateDataLength() int {
 	return 0
 }
 
+// returns the length of the adaptation field extension, if there is no adaptation field extension then its length is zero
 func (af AdaptationField) adaptationExtensionLength() int {
 	if af.HasAdaptationFieldExtension() {
 		// TODO: make new type and call its methods to find the length
@@ -65,6 +81,8 @@ func (af AdaptationField) adaptationExtensionLength() int {
 	return 0
 }
 
+// calculates the length of the Adaptation Field
+// (with respect to the start of the packet) excluding stuffing
 func (af AdaptationField) calculateMinLength() int {
 	if af.invalid() {
 		return 0
@@ -114,8 +132,13 @@ func (af AdaptationField) setLength(length int) {
 	af[4] = byte(length)
 }
 
+// resizeAF grows an adaptation field and erases the payload.
+// Alternatley, with a negative delta, it can shrink a packet
+// and keep the payload and stuff the empty space with stuffing bytes.
+// this function is called automatically, no need for the library user
+// to call it.
 func (af AdaptationField) resizeAF(start int, delta int) {
-	if delta > 0 { // growing
+	if delta > 0 { // shifting for growing
 		// move existing bytes to new location
 		payloadStart := af.calculateMinLength()
 		endNew := payloadStart - 1
@@ -126,17 +149,23 @@ func (af AdaptationField) resizeAF(start int, delta int) {
 			end--
 		}
 		packetEnd := len(af) - 1
+		// check if payload was corrupted/overwritten by growing
 		if af.Length() < payloadStart-5 {
-			// erase payload
+			// erase payload, it is corrupt anyways
 			for payloadStart <= packetEnd {
 				af[payloadStart] = 0xFF
 				payloadStart++
 			}
+			// packet is stuffed until the very end.
+			// this is an invalid packet since payload
+			// must be at least one byte in size.
+			// this will remind the user of the library
+			// that the payload was destroyed
 			af.setLength(183)
 		}
 	}
-	if delta < 0 { // shrinking
-		end := af.calculateMinLength() - delta
+	if delta < 0 { // shifting for shrinking
+		end := af.calculateMinLength() - 1 - delta
 		startNew := start
 		start := startNew - delta
 		for start <= end {
@@ -144,7 +173,7 @@ func (af AdaptationField) resizeAF(start int, delta int) {
 			startNew++
 			start++
 		}
-		//preserve payload size and stuff it
+		//stuff remaining bytes to preserve payload size
 		for startNew <= end {
 			af[startNew] = 0xFF
 			startNew++
@@ -227,7 +256,7 @@ func (af AdaptationField) SetHasTransportPrivateData(value bool) {
 		af.pcrLength()+
 		af.opcrLength()+
 		af.spliceCountdownLength(),
-		delta,
+		delta, // default len of Transport Private Data
 	)
 }
 

--- a/packet/adaptationfield_test.go
+++ b/packet/adaptationfield_test.go
@@ -32,7 +32,7 @@ func TestDiscontinuity(t *testing.T) {
 }
 
 func TestAdaptationField(t *testing.T) {
-	p := createPacketEmptyBody(t, "470000300102")
+	p := createPacketEmptyPayload(t, "470000300102")
 	a, err := p.AdaptationField()
 	if err != nil {
 		t.Errorf("error getting adaptation field")
@@ -41,7 +41,7 @@ func TestAdaptationField(t *testing.T) {
 		t.Errorf("no adaptation field was returned")
 	}
 
-	p = createPacketEmptyBody(t, "470000100002")
+	p = createPacketEmptyPayload(t, "470000100002")
 	a, err = p.AdaptationField()
 	if err != nil {
 		t.Errorf("error getting adaptation field")
@@ -56,29 +56,40 @@ func TestAll(t *testing.T) {
 	target, _ := generatePacketAF(t, "B710000000007E01")
 	a.SetHasPCR(true)
 	a.SetPCR(1)
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the PCR to 1 has failed.", generated, target)
+	}
 
 	target, _ = generatePacketAF(t, "B718000000007E01000000007E02")
 	a.SetHasOPCR(true)
 	a.SetOPCR(2)
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the OPCR to 2 has failed.", generated, target)
+	}
 
 	target, _ = generatePacketAF(t, "B71A000000007E01000000007E020188")
 	a.SetHasTransportPrivateData(true)
 	a.SetTransportPrivateData([]byte{0x88})
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Transport Private Data to 0x88 has failed.", generated, target)
+	}
 
-	target, _ = generatePacketAF(t, "B71B000000007E01000000007E0201880177")
+	target, _ = generatePacketAF(t, "B71B000000007E01000000007E0201880100")
 	a.SetHasAdaptationFieldExtension(true)
-	a.SetAdaptationFieldExtension([]byte{0x77})
-	assertPacket(t, target, generated)
+	a.SetAdaptationFieldExtension([]byte{0x00})
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Adaptation Field Extension to 0x00 has failed.", generated, target)
+	}
 
-	target, _ = generatePacketAF(t, "B71B000000007E01000000007E020266660177")
+	target, _ = generatePacketAF(t, "B71B000000007E01000000007E020266660100")
 	a.SetTransportPrivateData([]byte{0x66, 0x66})
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Transport Private Data to 0x6666 has failed.", generated, target)
+	}
 
-	target, _ = generatePacketAF(t, "B713000000007E010266660177")
+	target, _ = generatePacketAF(t, "B713000000007E010266660100")
 	a.SetHasOPCR(false)
-	assertPacket(t, target, generated)
-
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nremoving has failed.", generated, target)
+	}
 }

--- a/packet/adaptationfield_test.go
+++ b/packet/adaptationfield_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 )
 
-func generatePacketAF(t *testing.T, AFString string) (Packet, AdaptationField) {
+func generatePacketAF(t *testing.T, AFString string) (*Packet, AdaptationField) {
 	p := createPacketEmptyAdaptationField(t, "47000030"+AFString)
 	a, err := p.AdaptationField()
 	if err != nil {
@@ -37,7 +37,7 @@ func generatePacketAF(t *testing.T, AFString string) (Packet, AdaptationField) {
 	if a == nil {
 		t.Errorf("adaptation field does not exist")
 	}
-	return p, a
+	return &p, a
 }
 
 func TestDiscontinuity(t *testing.T) {
@@ -75,10 +75,13 @@ func TestAdaptationField(t *testing.T) {
 	}
 }
 
-func TestAll(t *testing.T) {
+func TestAdaptationFieldFull(t *testing.T) {
 	generated, a := generatePacketAF(t, "B700")
 	target, _ := generatePacketAF(t, "B710000000007E01")
-	a.SetHasPCR(true)
+	err := a.SetHasPCR(true)
+	if err != nil {
+		t.Errorf("failed to set pcr flag. Error: %s", err.Error())
+	}
 	a.SetPCR(1)
 	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the PCR to 1 has failed.", generated, target)

--- a/packet/adaptationfield_test.go
+++ b/packet/adaptationfield_test.go
@@ -59,7 +59,7 @@ func TestAdaptationField(t *testing.T) {
 	p := createPacketEmptyPayload(t, "470000300102")
 	a, err := p.AdaptationField()
 	if err != nil {
-		t.Errorf("error getting adaptation field")
+		t.Errorf("error getting adaptation field: %s", err.Error())
 	}
 	if a == nil {
 		t.Errorf("no adaptation field was returned")
@@ -67,8 +67,8 @@ func TestAdaptationField(t *testing.T) {
 
 	p = createPacketEmptyPayload(t, "470000100002")
 	a, err = p.AdaptationField()
-	if err != nil {
-		t.Errorf("error getting adaptation field")
+	if err == nil {
+		t.Error("no error was returned in trying to access a nonexistent adaptation field.")
 	}
 	if a != nil {
 		t.Errorf("adaptation field does not exist but something was returned.")
@@ -76,7 +76,7 @@ func TestAdaptationField(t *testing.T) {
 }
 
 func TestAll(t *testing.T) {
-	generated, a := generatePacketAF(t, "0100")
+	generated, a := generatePacketAF(t, "B700")
 	target, _ := generatePacketAF(t, "B710000000007E01")
 	a.SetHasPCR(true)
 	a.SetPCR(1)

--- a/packet/adaptationfield_test.go
+++ b/packet/adaptationfield_test.go
@@ -4,25 +4,25 @@ import (
 	"testing"
 )
 
-func generatePacketAF(t *testing.T, AFString string) AdaptationField {
-	p := createPacketEmptyBody(t, "47000030"+AFString)
+func generatePacketAF(t *testing.T, AFString string) (Packet, AdaptationField) {
+	p := createPacketEmptyAdaptationField(t, "47000030"+AFString)
 	a := p.AdaptationField()
 	if a == nil {
 		t.Errorf("failed to get adaptation field")
 	}
-	return a
+	return p, a
 }
 
 func TestDiscontinuity(t *testing.T) {
-	a := generatePacketAF(t, "0180")
+	_, a := generatePacketAF(t, "0180")
 	if !a.Discontinuity() {
 		t.Errorf("failed to read discontinuity correctly.")
 	}
-	a = generatePacketAF(t, "0190")
+	_, a = generatePacketAF(t, "0190")
 	if !a.Discontinuity() {
 		t.Errorf("failed to read discontinuity correctly.")
 	}
-	a = generatePacketAF(t, "0170")
+	_, a = generatePacketAF(t, "0170")
 	if a.Discontinuity() {
 		t.Errorf("failed to read discontinuity correctly.")
 	}
@@ -40,4 +40,36 @@ func TestAdaptationField(t *testing.T) {
 	if a != nil {
 		t.Errorf("Adaptation field does not exist but something was returned.")
 	}
+}
+
+func TestAll(t *testing.T) {
+	generated, a := generatePacketAF(t, "0100")
+	target, _ := generatePacketAF(t, "B710000000007E01")
+	a.SetHasPCR(true)
+	a.SetPCR(1)
+	assertPacket(t, target, generated)
+
+	target, _ = generatePacketAF(t, "B718000000007E01000000007E02")
+	a.SetHasOPCR(true)
+	a.SetOPCR(2)
+	assertPacket(t, target, generated)
+
+	target, _ = generatePacketAF(t, "B71A000000007E01000000007E020188")
+	a.SetHasTransportPrivateData(true)
+	a.SetTransportPrivateData([]byte{0x88})
+	assertPacket(t, target, generated)
+
+	target, _ = generatePacketAF(t, "B71B000000007E01000000007E0201880177")
+	a.SetHasAdaptationFieldExtension(true)
+	a.SetAdaptationFieldExtension([]byte{0x77})
+	assertPacket(t, target, generated)
+
+	target, _ = generatePacketAF(t, "B71B000000007E01000000007E020266660177")
+	a.SetTransportPrivateData([]byte{0x66, 0x66})
+	assertPacket(t, target, generated)
+
+	target, _ = generatePacketAF(t, "B713000000007E010266660177")
+	a.SetHasOPCR(false)
+	assertPacket(t, target, generated)
+
 }

--- a/packet/adaptationfield_test.go
+++ b/packet/adaptationfield_test.go
@@ -1,3 +1,27 @@
+/*
+MIT License
+
+Copyright 2016 Comcast Cable Communications Management, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 package packet
 
 import (

--- a/packet/adaptationfield_test.go
+++ b/packet/adaptationfield_test.go
@@ -25,6 +25,7 @@ SOFTWARE.
 package packet
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -43,15 +44,112 @@ func generatePacketAF(t *testing.T, AFString string) (*Packet, *AdaptationField)
 func TestDiscontinuity(t *testing.T) {
 	_, a := generatePacketAF(t, "0180")
 	if discontinuity, err := a.Discontinuity(); !discontinuity || err != nil {
-		t.Errorf("failed to read discontinuity correctly.")
+		t.Errorf("failed to read discontinuity correctly. expected false got true.")
 	}
 	_, a = generatePacketAF(t, "0190")
 	if discontinuity, err := a.Discontinuity(); !discontinuity || err != nil {
-		t.Errorf("failed to read discontinuity correctly.")
+		t.Errorf("failed to read discontinuity correctly. expected true got false.")
 	}
 	_, a = generatePacketAF(t, "0170")
 	if discontinuity, err := a.Discontinuity(); discontinuity || err != nil {
-		t.Errorf("failed to read discontinuity correctly.")
+		t.Errorf("failed to read discontinuity correctly. expected false got true.")
+	}
+}
+
+func TestSetDiscontinuity(t *testing.T) {
+	target, _ := generatePacketAF(t, "0180")
+	generated, a := generatePacketAF(t, "0100")
+	a.SetDiscontinuity(true)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Discontinuity to true has failed.", *generated, *target)
+	}
+	target, _ = generatePacketAF(t, "0100")
+	generated, a = generatePacketAF(t, "0180")
+	a.SetDiscontinuity(false)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Discontinuity to false has failed.", *generated, *target)
+	}
+}
+
+func TestRandomAccess(t *testing.T) {
+	_, a := generatePacketAF(t, "0140")
+	if randomAccess, err := a.RandomAccess(); !randomAccess || err != nil {
+		t.Errorf("failed to read RandomAccess correctly. expected true got false.")
+	}
+	_, a = generatePacketAF(t, "0130")
+	if randomAccess, err := a.RandomAccess(); randomAccess || err != nil {
+		t.Errorf("failed to read RandomAccess correctly. expected false got true.")
+	}
+}
+
+func TestSetRandomAccess(t *testing.T) {
+	target, _ := generatePacketAF(t, "0140")
+	generated, a := generatePacketAF(t, "0100")
+	a.SetRandomAccess(true)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the RandomAccess to true has failed.", *generated, *target)
+	}
+	target, _ = generatePacketAF(t, "0100")
+	generated, a = generatePacketAF(t, "0140")
+	a.SetRandomAccess(false)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the RandomAccess to false has failed.", *generated, *target)
+	}
+}
+
+func TestElementaryStreamPriority(t *testing.T) {
+	_, a := generatePacketAF(t, "0120")
+	if esp, err := a.ElementaryStreamPriority(); !esp || err != nil {
+		t.Errorf("failed to read ElementaryStreamPriority correctly. expected true got false.")
+	}
+	_, a = generatePacketAF(t, "0110")
+	if esp, err := a.ElementaryStreamPriority(); esp || err != nil {
+		t.Errorf("failed to read ElementaryStreamPriority correctly. expected false got true.")
+	}
+}
+
+func TestSetElementaryStreamPriority(t *testing.T) {
+	target, _ := generatePacketAF(t, "0120")
+	generated, a := generatePacketAF(t, "0100")
+	a.SetElementaryStreamPriority(true)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the ElementaryStreamPriority to true has failed.", *generated, *target)
+	}
+	target, _ = generatePacketAF(t, "0100")
+	generated, a = generatePacketAF(t, "0120")
+	a.SetElementaryStreamPriority(false)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the ElementaryStreamPriority to false has failed.", *generated, *target)
+	}
+}
+
+func TestHasSplicingPoint(t *testing.T) {
+	_, a := generatePacketAF(t, "0104")
+	if hsp, err := a.HasSplicingPoint(); !hsp || err != nil {
+		t.Errorf("failed to read HasSplicingPoint correctly. expected true got false.")
+	}
+	_, a = generatePacketAF(t, "0111")
+	if hsp, err := a.HasSplicingPoint(); hsp || err != nil {
+		t.Errorf("failed to read HasSplicingPoint correctly. expected false got true.")
+	}
+}
+
+func TestSetHasSplicingPoint(t *testing.T) {
+	target, _ := generatePacketAF(t, "0F04")
+	generated, a := generatePacketAF(t, "0100")
+	if a.SetHasSplicingPoint(true) == nil {
+		t.Error("adaptation field cannot fit a splice countdown field but no error was returned")
+	}
+	generated, a = generatePacketAF(t, "0F00")
+	a.SetHasSplicingPoint(true)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the HasSplicingPoint to true has failed.", *generated, *target)
+	}
+	target, _ = generatePacketAF(t, "0100")
+	generated, a = generatePacketAF(t, "0104")
+	a.SetHasSplicingPoint(false)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the HasSplicingPoint to false has failed.", *generated, *target)
 	}
 }
 
@@ -84,39 +182,124 @@ func TestAdaptationFieldFull(t *testing.T) {
 	}
 	a.SetPCR(1)
 	if !Equal(generated, target) {
-		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the PCR to 1 has failed.", generated, target)
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the PCR to 1 has failed.", *generated, *target)
 	}
 
 	target, _ = generatePacketAF(t, "B718000000007E01000000007E02")
 	a.SetHasOPCR(true)
 	a.SetOPCR(2)
 	if !Equal(generated, target) {
-		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the OPCR to 2 has failed.", generated, target)
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the OPCR to 2 has failed.", *generated, *target)
 	}
 
 	target, _ = generatePacketAF(t, "B71A000000007E01000000007E020188")
 	a.SetHasTransportPrivateData(true)
 	a.SetTransportPrivateData([]byte{0x88})
 	if !Equal(generated, target) {
-		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Transport Private Data to 0x88 has failed.", generated, target)
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Transport Private Data to 0x88 has failed.", *generated, *target)
 	}
 
 	target, _ = generatePacketAF(t, "B71B000000007E01000000007E0201880100")
 	a.SetHasAdaptationFieldExtension(true)
 	a.SetAdaptationFieldExtension([]byte{0x00})
 	if !Equal(generated, target) {
-		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Adaptation Field Extension to 0x00 has failed.", generated, target)
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Adaptation Field Extension to 0x00 has failed.", *generated, *target)
 	}
 
 	target, _ = generatePacketAF(t, "B71B000000007E01000000007E020266660100")
 	a.SetTransportPrivateData([]byte{0x66, 0x66})
 	if !Equal(generated, target) {
-		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Transport Private Data to 0x6666 has failed.", generated, target)
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Transport Private Data to 0x6666 has failed.", *generated, *target)
 	}
 
 	target, _ = generatePacketAF(t, "B713000000007E010266660100")
 	a.SetHasOPCR(false)
 	if !Equal(generated, target) {
-		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nremoving has failed.", generated, target)
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nremoving has failed.", *generated, *target)
+	}
+
+	target, _ = generatePacketAF(t, "B717000000007E01510266660100")
+	a.SetHasSplicingPoint(true)
+	a.SetSpliceCountdown(0x51)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Transport Private Data to 0x6666 has failed.", *generated, *target)
+	}
+
+	a.SetHasOPCR(true)
+	a.SetOPCR(2)
+
+	hasPCR, err := a.HasPCR()
+	if err != nil {
+		t.Errorf("failed to get HasPCR. error: %s", err.Error())
+	}
+	if hasPCR != true {
+		t.Errorf("generated HasPCR (%t) does not match expected HasPCR (%t)", hasPCR, true)
+	}
+	pcr, err := a.PCR()
+	if err != nil {
+		t.Errorf("failed to get PCR. error: %s", err.Error())
+	}
+	if pcr != 1 {
+		t.Errorf("generated PCR (%d) does not match expected PCR (%d)", pcr, 1)
+	}
+
+	hasOPCR, err := a.HasOPCR()
+	if err != nil {
+		t.Errorf("failed to get HasPCR. error: %s", err.Error())
+	}
+	if hasOPCR != true {
+		t.Errorf("generated HasPCR (%t) does not match expected HasPCR (%t)", hasOPCR, true)
+	}
+	opcr, err := a.OPCR()
+	if err != nil {
+		t.Errorf("failed to get OPCR. error: %s", err.Error())
+	}
+	if opcr != 2 {
+		t.Errorf("generated OPCR (%d) does not match expected OPCR (%d)", opcr, 2)
+	}
+
+	hasSplicingPoint, err := a.HasSplicingPoint()
+	if err != nil {
+		t.Errorf("failed to get HasSplicingPoint. error: %s", err.Error())
+	}
+	if hasSplicingPoint != true {
+		t.Errorf("generated hasSplicingPoint (%t) does not match expected hasSplicingPoint (%t)", hasSplicingPoint, true)
+	}
+	spliceCountdown, err := a.SpliceCountdown()
+	if err != nil {
+		t.Errorf("failed to get spliceCountdown. error: %s", err.Error())
+	}
+	if spliceCountdown != 0x51 {
+		t.Errorf("generated spliceCountdown (0x%X) does not match expected spliceCountdown (0x%X)", spliceCountdown, 0x51)
+	}
+
+	hasTPD, err := a.HasTransportPrivateData()
+	if err != nil {
+		t.Errorf("failed to get hasTPD. error: %s", err.Error())
+	}
+	if hasTPD != true {
+		t.Errorf("generated HasTransportPrivateData (%t) does not match expected HasTransportPrivateData (%t)", hasTPD, true)
+	}
+	tpd, err := a.TransportPrivateData()
+	if err != nil {
+		t.Errorf("failed to get TransportPrivateData. error: %s", err.Error())
+	}
+	if bytes.Equal(tpd, []byte{0x66, 0x66}) {
+		t.Errorf("generated TransportPrivateData (0x%X) does not match expected TransportPrivateData (0x%X)", tpd, []byte{0x66, 0x66})
+	}
+
+	hasAFE, err := a.HasAdaptationFieldExtension()
+	if err != nil {
+		t.Errorf("failed to get HasAdaptationFieldExtension. error: %s", err.Error())
+	}
+	if hasAFE != true {
+		t.Errorf("generated HasAdaptationFieldExtension (%t) does not match expected HasAdaptationFieldExtension (%t)", hasAFE, true)
+	}
+	afe, err := a.AdaptationFieldExtension()
+	if err != nil {
+		t.Errorf("failed to get AdaptationFieldExtension. error: %s", err.Error())
+	}
+	if bytes.Equal(afe, []byte{0x00}) {
+		t.Errorf("generated AdaptationFieldExtension (0x%X) does not match expected AdaptationFieldExtension (0x%X)", tpd, []byte{0x00})
 	}
 }

--- a/packet/adaptationfield_test.go
+++ b/packet/adaptationfield_test.go
@@ -6,39 +6,48 @@ import (
 
 func generatePacketAF(t *testing.T, AFString string) (Packet, AdaptationField) {
 	p := createPacketEmptyAdaptationField(t, "47000030"+AFString)
-	a := p.AdaptationField()
+	a, err := p.AdaptationField()
+	if err != nil {
+		t.Errorf("failed to get adaptation field. error: %s", err.Error())
+	}
 	if a == nil {
-		t.Errorf("failed to get adaptation field")
+		t.Errorf("adaptation field does not exist")
 	}
 	return p, a
 }
 
 func TestDiscontinuity(t *testing.T) {
 	_, a := generatePacketAF(t, "0180")
-	if !a.Discontinuity() {
+	if discontinuity, err := a.Discontinuity(); !discontinuity || err != nil {
 		t.Errorf("failed to read discontinuity correctly.")
 	}
 	_, a = generatePacketAF(t, "0190")
-	if !a.Discontinuity() {
+	if discontinuity, err := a.Discontinuity(); !discontinuity || err != nil {
 		t.Errorf("failed to read discontinuity correctly.")
 	}
 	_, a = generatePacketAF(t, "0170")
-	if a.Discontinuity() {
+	if discontinuity, err := a.Discontinuity(); discontinuity || err != nil {
 		t.Errorf("failed to read discontinuity correctly.")
 	}
 }
 
 func TestAdaptationField(t *testing.T) {
 	p := createPacketEmptyBody(t, "470000300102")
-	a := p.AdaptationField()
+	a, err := p.AdaptationField()
+	if err != nil {
+		t.Errorf("error getting adaptation field")
+	}
 	if a == nil {
-		t.Errorf("Error getting adaptation field.")
+		t.Errorf("no adaptation field was returned")
 	}
 
 	p = createPacketEmptyBody(t, "470000100002")
-	a = p.AdaptationField()
+	a, err = p.AdaptationField()
+	if err != nil {
+		t.Errorf("error getting adaptation field")
+	}
 	if a != nil {
-		t.Errorf("Adaptation field does not exist but something was returned.")
+		t.Errorf("adaptation field does not exist but something was returned.")
 	}
 }
 

--- a/packet/adaptationfield_test.go
+++ b/packet/adaptationfield_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 )
 
-func generatePacketAF(t *testing.T, AFString string) (*Packet, AdaptationField) {
+func generatePacketAF(t *testing.T, AFString string) (*Packet, *AdaptationField) {
 	p := createPacketEmptyAdaptationField(t, "47000030"+AFString)
 	a, err := p.AdaptationField()
 	if err != nil {

--- a/packet/adaptationfield_test.go
+++ b/packet/adaptationfield_test.go
@@ -1,0 +1,43 @@
+package packet
+
+import (
+	"testing"
+)
+
+func generatePacketAF(t *testing.T, AFString string) AdaptationField {
+	p := createPacketEmptyBody(t, "47000030"+AFString)
+	a := p.AdaptationField()
+	if a == nil {
+		t.Errorf("failed to get adaptation field")
+	}
+	return a
+}
+
+func TestDiscontinuity(t *testing.T) {
+	a := generatePacketAF(t, "0180")
+	if !a.Discontinuity() {
+		t.Errorf("failed to read discontinuity correctly.")
+	}
+	a = generatePacketAF(t, "0190")
+	if !a.Discontinuity() {
+		t.Errorf("failed to read discontinuity correctly.")
+	}
+	a = generatePacketAF(t, "0170")
+	if a.Discontinuity() {
+		t.Errorf("failed to read discontinuity correctly.")
+	}
+}
+
+func TestAdaptationField(t *testing.T) {
+	p := createPacketEmptyBody(t, "470000300102")
+	a := p.AdaptationField()
+	if a == nil {
+		t.Errorf("Error getting adaptation field.")
+	}
+
+	p = createPacketEmptyBody(t, "470000100002")
+	a = p.AdaptationField()
+	if a != nil {
+		t.Errorf("Adaptation field does not exist but something was returned.")
+	}
+}

--- a/packet/doc.go
+++ b/packet/doc.go
@@ -58,7 +58,7 @@ const (
 type Packet [PacketSize]byte
 
 // AdaptationField is an optional part of the packet.
-type AdaptationField []byte
+type AdaptationField Packet
 
 // Accumulator is used to gather multiple packets
 // and return their concatenated payloads.

--- a/packet/doc.go
+++ b/packet/doc.go
@@ -34,6 +34,8 @@ const (
 	NullPacketPid = 8191
 )
 
+// TransportScramblingControlOptions is a set of constants for
+// selecting the transport scrambling control.
 type TransportScramblingControlOptions byte
 
 const (
@@ -42,6 +44,8 @@ const (
 	ScrambleOddKeyFlag  TransportScramblingControlOptions = 3 // 11
 )
 
+// AdaptationFieldControlOptions is a set of constants for
+// selecting the adaptation field control.
 type AdaptationFieldControlOptions byte
 
 const (
@@ -52,6 +56,9 @@ const (
 
 // Packet is the basic unit in a transport stream.
 type Packet []byte
+
+// AdaptationField is an optional part of the packet.
+type AdaptationField []byte
 
 // Accumulator is used to gather multiple packets
 // and return their concatenated payloads.

--- a/packet/doc.go
+++ b/packet/doc.go
@@ -31,7 +31,23 @@ const (
 	// SyncByte is the expected value of the sync byte
 	SyncByte = 71 // 0x47
 	// NullPacketPid is the pid reserved for null packets
-	NullPacketPid = uint16(8191)
+	NullPacketPid = 8191
+)
+
+type TransportScramblingControlOptions byte
+
+const (
+	NoScrambleFlag      TransportScramblingControlOptions = 0 // 00
+	ScrambleEvenKeyFlag TransportScramblingControlOptions = 2 // 10
+	ScrambleOddKeyFlag  TransportScramblingControlOptions = 3 // 11
+)
+
+type AdaptationFieldControlOptions byte
+
+const (
+	PayloadFlag                   AdaptationFieldControlOptions = 1 // 10
+	AdaptationFieldFlag           AdaptationFieldControlOptions = 2 // 01
+	PayloadAndAdaptationFieldFlag AdaptationFieldControlOptions = 3 // 11
 )
 
 // Packet is the basic unit in a transport stream.

--- a/packet/doc.go
+++ b/packet/doc.go
@@ -31,7 +31,7 @@ const (
 	// SyncByte is the expected value of the sync byte
 	SyncByte = 71 // 0x47
 	// NullPacketPid is the pid reserved for null packets
-	NullPacketPid = 8191
+	NullPacketPid = 8191 // 0x1FFF
 )
 
 // TransportScramblingControlOptions is a set of constants for

--- a/packet/modify.go
+++ b/packet/modify.go
@@ -87,7 +87,7 @@ func (p Packet) SetTransportPriority(value bool) error {
 	return p.setBit(1, 0x20, value)
 }
 
-// TP returns the Transport Priority flag
+// TransportPriority returns the Transport Priority flag
 func (p Packet) TransportPriority() (bool, error) {
 	return p.getBit(1, 0x20)
 }

--- a/packet/modify.go
+++ b/packet/modify.go
@@ -1,3 +1,27 @@
+/*
+MIT License
+
+Copyright 2016 Comcast Cable Communications Management, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 package packet
 
 import (

--- a/packet/modify.go
+++ b/packet/modify.go
@@ -5,17 +5,26 @@ import (
 	"github.com/Comcast/gots"
 )
 
+// flags that are reserved and should not be used.
 const (
 	invalidTransportScramblingControlFlag TransportScramblingControlOptions = 1 // 01
 	invalidAdaptationFieldControlFlag     AdaptationFieldControlOptions     = 0 // 00
 )
 
+// NewPacket creates a new packet with a Null ID, sync byte, and with the adaptation field control set to payload only.
 func NewPacket() (pkt Packet) {
 	pkt = make(Packet, PacketSize)
-	pkt[0] = 0x47
+	//Default packet is the Null packet
+	pkt[0] = 0x47 // sets the sync byte
+	pkt[1] = 0x1F // equivalent to pkt.SetPID(NullPacketPid)
+	pkt[2] = 0xFF // equivalent to pkt.SetPID(NullPacketPid)
+	pkt[3] = 0x10 // equivalent to pkt.SetAdaptationFieldControl(PayloadFlag)
 	return
 }
 
+// FromBytes creates a ts packet from a slice of bytes 188 in length.
+// If the bytes provided have errors or the slice is not 188 in length,
+// then an error vill be returned along with a nill slice.
 func FromBytes(bytes []byte) (pkt Packet, err error) {
 	pkt = Packet(bytes)
 	err = pkt.CheckErrors()
@@ -29,6 +38,9 @@ func (p Packet) SetTransportErrorIndicator(value bool) {
 
 // TransportErrorIndicator returns the Transport Error Indicator
 func (p Packet) TransportErrorIndicator() bool {
+	if p.badLen() {
+		return false // defalt value for nil packet
+	}
 	return p.getBit(1, 0x80)
 }
 
@@ -45,72 +57,129 @@ func (p Packet) SetPayloadUnitStartIndicator(value bool) {
 // (Program-Specific Information) such as AT, CAT, PMT or NIT.  The PUSI
 // flag is contained in the second bit of the second byte of the Packet.
 func (p Packet) PayloadUnitStartIndicator() bool {
+	if p.badLen() {
+		return false // defalt value for nil packet
+	}
 	return p.getBit(1, 0x40)
 }
 
+// SetTransportPriority sets the Transport Priority flag
 func (p Packet) SetTransportPriority(value bool) {
 	p.setBit(1, 0x20, value)
 }
 
+// TP returns the Transport Priority flag
 func (p Packet) TransportPriority() bool {
+	if p.badLen() {
+		return false // defalt value for nil packet
+	}
 	return p.getBit(1, 0x20)
 }
 
+// SetPID sets the program ID
 func (p Packet) SetPID(pid int) {
+	if p.badLen() {
+		return
+	}
 	p[1] = p[1]&^byte(0x1f) | byte(pid>>8)&byte(0x1f)
 	p[2] = byte(pid)
 }
 
+// PID Returns the program ID
 func (p Packet) PID() int {
+	if p.badLen() {
+		return NullPacketPid // defalt value for nil packet
+	}
 	return int(p[1]&0x1f)<<8 | int(p[2])
 }
 
+// SetTransportScramblingControl sets the Transport Scrambling Control flag.
 func (p Packet) SetTransportScramblingControl(value TransportScramblingControlOptions) {
+	if p.badLen() {
+		return
+	}
 	p[3] = p[3]&^byte(0xC0) | byte(value)<<6
 }
 
+// TransportScramblingControl returns the Transport Scrambling Control flag.
 func (p Packet) TransportScramblingControl() TransportScramblingControlOptions {
+	if p.badLen() {
+		return NoScrambleFlag // defalt value for nil packet
+	}
 	return TransportScramblingControlOptions((p[3] & 0xC0) >> 6)
 }
 
+// SetAdaptationFieldControl sets the Adaptation Field Control flag.
 func (p Packet) SetAdaptationFieldControl(value AdaptationFieldControlOptions) {
 	p[3] = p[3]&^byte(0x30) | byte(value)<<4
 	// TODO: adaptation field class
 }
 
+// AdaptationFieldControl returns the Adaptation Field Control.
 func (p Packet) AdaptationFieldControl() AdaptationFieldControlOptions {
+	if p.badLen() {
+		return PayloadFlag // defalt value for nil packet
+	}
 	return AdaptationFieldControlOptions((p[3] & 0x30) >> 4)
 }
 
+// HasPayload returns true if the adaptation field control specifies that there is a payload.
 func (p Packet) HasPayload() bool {
+	if p.badLen() {
+		return true // defalt value for nil packet
+	}
 	return p.getBit(3, 0x10)
 }
 
+// HasPayload returns true if the adaptation field control specifies that there is an adaptation field.
 func (p Packet) HasAdaptationField() bool {
+	if p.badLen() {
+		return false // defalt value for nil packet
+	}
 	return p.getBit(3, 0x20)
 }
 
-// overflows after 15 and starts againat 0
+// SetContinuityCounter sets the continuity counter.
+// The continuity counter should be an integer between 0 and 15.
+// If the number is out of this range then it will discard the extra bits.
+// The effect is the same as modulus by 16.
 func (p Packet) SetContinuityCounter(value int) {
+	if p.badLen() {
+		return
+	}
+	// if value is greater than 15 it will overflow and start at 0 again.
 	p[3] = p[3]&^byte(0x0F) | byte(value&0x0F)
 }
 
+// ContinuityCounter returns the continuity counter.
+// The continuity counter is an integer between 0 and 15.
 func (p Packet) ContinuityCounter() int {
+	if p.badLen() {
+		return 0 // defalt value for nil packet
+	}
 	return int(p[3] & 0x0F)
 }
 
+// SetContinuityCounter sets the continuity counter to 0.
 func (p Packet) ZeroContinuityCounter() {
 	p.SetContinuityCounter(0)
 }
 
+// IncContinuityCounter increments the continuity counter.
+// The continuity counter is an integer between 0 and 15.
+// If the number is out of this range (overflow)
+// after incrementing then it will discard the extra bits.
+// The effect is the same as modulus by 16.
 func (p Packet) IncContinuityCounter() {
 	p.SetContinuityCounter(p.ContinuityCounter() + 1)
 }
 
+// IsNull returns true if the packet PID is equal to 8191, the null packet pid.
 func (p Packet) IsNull() bool {
 	return p.PID() == NullPacketPid
 }
 
+// IsNull returns true if the packet PID is equal to 0, the PAT packet pid.
 func (p Packet) IsPAT() bool {
 	return p.PID() == 0
 }
@@ -142,9 +211,18 @@ func (p Packet) syncByte() byte {
 	return p[0]
 }
 
+// badLen returns true if the length of the packet slice is
+// anything but PacketSize (188)
+func (p Packet) badLen() bool {
+	return len(p) != PacketSize
+}
+
 // setBit sets a bit in a packet. If packet is nil, or slice has a bad
 // length, it does nothing.
 func (p Packet) setBit(index int, mask byte, value bool) {
+	if p.badLen() {
+		return
+	}
 	if value {
 		p[index] |= mask
 	} else {

--- a/packet/modify.go
+++ b/packet/modify.go
@@ -1,0 +1,158 @@
+package packet
+
+import (
+	"bytes"
+	"github.com/Comcast/gots"
+)
+
+const (
+	invalidTransportScramblingControlFlag TransportScramblingControlOptions = 1 // 01
+	invalidAdaptationFieldControlFlag     AdaptationFieldControlOptions     = 0 // 00
+)
+
+func NewPacket() (pkt Packet) {
+	pkt = make(Packet, PacketSize)
+	pkt[0] = 0x47
+	return
+}
+
+func FromBytes(bytes []byte) (pkt Packet, err error) {
+	pkt = Packet(bytes)
+	err = pkt.CheckErrors()
+	return
+}
+
+// SetTransportErrorIndicator sets the Transport Error Indicator flag.
+func (p Packet) SetTransportErrorIndicator(value bool) {
+	p.setBit(1, 0x80, value)
+}
+
+// TransportErrorIndicator returns the Transport Error Indicator
+func (p Packet) TransportErrorIndicator() bool {
+	return p.getBit(1, 0x80)
+}
+
+// SetPayloadUnitStartIndicator sets the Payload unit start indicator (PUSI) flag
+// PUSI is a flag that indicates the start of PES data or PSI
+// (Program-Specific Information) such as AT, CAT, PMT or NIT.  The PUSI
+// flag is contained in the second bit of the second byte of the Packet.
+func (p Packet) SetPayloadUnitStartIndicator(value bool) {
+	p.setBit(1, 0x40, value)
+}
+
+// PayloadUnitStartIndicator returns the Payload unit start indicator (PUSI) flag
+// PUSI is a flag that indicates the start of PES data or PSI
+// (Program-Specific Information) such as AT, CAT, PMT or NIT.  The PUSI
+// flag is contained in the second bit of the second byte of the Packet.
+func (p Packet) PayloadUnitStartIndicator() bool {
+	return p.getBit(1, 0x40)
+}
+
+func (p Packet) SetTransportPriority(value bool) {
+	p.setBit(1, 0x20, value)
+}
+
+func (p Packet) TransportPriority() bool {
+	return p.getBit(1, 0x20)
+}
+
+func (p Packet) SetPID(pid int) {
+	p[1] = p[1]&^byte(0x1f) | byte(pid>>8)&byte(0x1f)
+	p[2] = byte(pid)
+}
+
+func (p Packet) PID() int {
+	return int(p[1]&0x1f)<<8 | int(p[2])
+}
+
+func (p Packet) SetTransportScramblingControl(value TransportScramblingControlOptions) {
+	p[3] = p[3]&^byte(0xC0) | byte(value)<<6
+}
+
+func (p Packet) TransportScramblingControl() TransportScramblingControlOptions {
+	return TransportScramblingControlOptions((p[3] & 0xC0) >> 6)
+}
+
+func (p Packet) SetAdaptationFieldControl(value AdaptationFieldControlOptions) {
+	p[3] = p[3]&^byte(0x30) | byte(value)<<4
+	// TODO: adaptation field class
+}
+
+func (p Packet) AdaptationFieldControl() AdaptationFieldControlOptions {
+	return AdaptationFieldControlOptions((p[3] & 0x30) >> 4)
+}
+
+func (p Packet) HasPayload() bool {
+	return p.getBit(3, 0x10)
+}
+
+func (p Packet) HasAdaptationField() bool {
+	return p.getBit(3, 0x20)
+}
+
+// overflows after 15 and starts againat 0
+func (p Packet) SetContinuityCounter(value int) {
+	p[3] = p[3]&^byte(0x0F) | byte(value&0x0F)
+}
+
+func (p Packet) ContinuityCounter() int {
+	return int(p[3] & 0x0F)
+}
+
+func (p Packet) ZeroContinuityCounter() {
+	p.SetContinuityCounter(0)
+}
+
+func (p Packet) IncContinuityCounter() {
+	p.SetContinuityCounter(p.ContinuityCounter() + 1)
+}
+
+func (p Packet) IsNull() bool {
+	return p.PID() == NullPacketPid
+}
+
+func (p Packet) IsPAT() bool {
+	return p.PID() == 0
+}
+
+// Equal returns true if the bytes of the two packets are equal
+func (p Packet) Equals(r Packet) bool {
+	return bytes.Equal(p, r)
+}
+
+// CheckErrors checks the packet for errors
+func (p Packet) CheckErrors() error {
+	if len(p) != PacketSize {
+		return gots.ErrInvalidPacketLength
+	}
+	if p.syncByte() != SyncByte {
+		return gots.ErrBadSyncByte
+	}
+	if p.TransportScramblingControl() == invalidTransportScramblingControlFlag {
+		return gots.ErrInvalidTSCFlag
+	}
+	if p.AdaptationFieldControl() == invalidAdaptationFieldControlFlag {
+		return gots.ErrInvalidAFCFlag
+	}
+	return nil
+}
+
+// syncByte returns the Sync byte.
+func (p Packet) syncByte() byte {
+	return p[0]
+}
+
+// setBit sets a bit in a packet. If packet is nil, or slice has a bad
+// length, it does nothing.
+func (p Packet) setBit(index int, mask byte, value bool) {
+	if value {
+		p[index] |= mask
+	} else {
+		p[index] &= ^mask
+	}
+}
+
+// getBit returns true if a bit in a packet is set to 1.
+func (p Packet) getBit(index int, mask byte) bool {
+	return p[index]&mask != 0
+}

--- a/packet/modify_test.go
+++ b/packet/modify_test.go
@@ -29,6 +29,24 @@ func createPacketEmptyBody(t *testing.T, header string) (p Packet) {
 	return
 }
 
+func createPacketEmptyAdaptationField(t *testing.T, header string) (p Packet) {
+	headerBytes, _ := hex.DecodeString(header)
+	AFBytes := make([]byte, 188)
+	AFBytes[4] = 183
+	AFBytes[5] = 0
+	for i := 6; i < len(AFBytes); i++ {
+		AFBytes[i] = 0xFF
+	}
+	AFBytes = AFBytes[len(headerBytes):188]
+	packetByets := Packet(append(headerBytes, AFBytes...))
+
+	p, err := FromBytes(packetByets)
+	if err != nil {
+		t.Error("packet Error checking failed.")
+	}
+	return
+}
+
 func assertPacket(t *testing.T, target Packet, generated Packet) {
 	if err := target.CheckErrors(); err != nil {
 		t.Error("error in target packet")
@@ -186,15 +204,15 @@ func TestTransportScramblingControl(t *testing.T) {
 func TestSetAdaptationFieldControl(t *testing.T) {
 	generated := NewPacket()
 
-	target := createPacketEmptyBody(t, "471FFF1000")
+	target := createPacketEmptyBody(t, "471FFF10")
 	generated.SetAdaptationFieldControl(PayloadFlag)
 	assertPacket(t, target, generated)
 
-	target = createPacketEmptyBody(t, "471FFF3001")
+	target = createPacketEmptyAdaptationField(t, "471FFF30")
 	generated.SetAdaptationFieldControl(PayloadAndAdaptationFieldFlag)
 	assertPacket(t, target, generated)
 
-	target = createPacketEmptyBody(t, "471FFF2001")
+	target = createPacketEmptyAdaptationField(t, "471FFF20")
 	generated.SetAdaptationFieldControl(AdaptationFieldFlag)
 	assertPacket(t, target, generated)
 }
@@ -204,11 +222,11 @@ func TestAdaptationFieldControl(t *testing.T) {
 	if pkt.AdaptationFieldControl() != PayloadFlag {
 		t.Error("Failed to set AdaptationFieldControl to PayloadFlag.")
 	}
-	pkt = createPacketEmptyBody(t, "471FFFB001")
+	pkt = createPacketEmptyAdaptationField(t, "471FFFB001")
 	if pkt.AdaptationFieldControl() != PayloadAndAdaptationFieldFlag {
 		t.Error("Failed to set AdaptationFieldControl to PayloadAndAdaptationFieldFlag.")
 	}
-	pkt = createPacketEmptyBody(t, "471FFFA001")
+	pkt = createPacketEmptyAdaptationField(t, "471FFFA001")
 	if pkt.AdaptationFieldControl() != AdaptationFieldFlag {
 		t.Error("Failed to set AdaptationFieldControl to AdaptationFieldFlag.")
 	}

--- a/packet/modify_test.go
+++ b/packet/modify_test.go
@@ -347,35 +347,65 @@ func TestIsNull(t *testing.T) {
 	}
 }
 
-// func TestHasAdaptationField(t *testing.T) {
-// 	pkt := createPacketEmptyBody(t, "471FFF100100")
-// 	if pkt.HasAdaptationField() {
-// 		t.Errorf("Packet should not have Adaptation Field (AdaptationFieldControl = 01).")
-// 	}
-// 	pkt = createPacketEmptyBody(t, "471FFF200100")
-// 	if !pkt.HasAdaptationField() {
-// 		t.Errorf("Packet should have Adaptation Field (AdaptationFieldControl = 10).")
-// 	}
-// 	pkt = createPacketEmptyBody(t, "471FFF300100")
-// 	if !pkt.HasAdaptationField() {
-// 		t.Errorf("Packet should have Adaptation Field (AdaptationFieldControl = 11).")
-// 	}
-// }
-//
-// func TestHasPayload(t *testing.T) {
-// 	pkt := createPacketEmptyBody(t, "471FFF10")
-// 	if !pkt.HasPayload() {
-// 		t.Errorf("Packet should have Payload (AdaptationFieldControl = 01).")
-// 	}
-// 	pkt = createPacketEmptyBody(t, "471FFF20")
-// 	if pkt.HasPayload() {
-// 		t.Errorf("Packet should not have Payload (AdaptationFieldControl = 10).")
-// 	}
-// 	pkt = createPacketEmptyBody(t, "471FFF30")
-// 	if !pkt.HasPayload() {
-// 		t.Errorf("Packet should have Payload (AdaptationFieldControl = 11).")
-// 	}
-// }
+func TestHasAdaptationField(t *testing.T) {
+	pkt := createPacketEmptyBody(t, "471FFF100100")
+	hasAF, err := pkt.HasAdaptationField()
+	if err != nil {
+		t.Errorf("could not run has adaptation field. error: %s", err.Error())
+		return
+	}
+	if hasAF {
+		t.Errorf("Packet should not have Adaptation Field (AdaptationFieldControl = 01).")
+	}
+	pkt = createPacketEmptyBody(t, "471FFF200100")
+	hasAF, err = pkt.HasAdaptationField()
+	if err != nil {
+		t.Errorf("could not run has adaptation field. error: %s", err.Error())
+		return
+	}
+	if !hasAF {
+		t.Errorf("Packet should have Adaptation Field (AdaptationFieldControl = 10).")
+	}
+	pkt = createPacketEmptyBody(t, "471FFF300100")
+	hasAF, err = pkt.HasAdaptationField()
+	if err != nil {
+		t.Errorf("could not run has adaptation field. error: %s", err.Error())
+		return
+	}
+	if !hasAF {
+		t.Errorf("Packet should have Adaptation Field (AdaptationFieldControl = 11).")
+	}
+}
+
+func TestHasPayload(t *testing.T) {
+	pkt := createPacketEmptyBody(t, "471FFF10")
+	hasPayload, err := pkt.HasPayload()
+	if err != nil {
+		t.Errorf("could not run has payload. error: %s", err.Error())
+		return
+	}
+	if !hasPayload {
+		t.Errorf("Packet should have Payload (AdaptationFieldControl = 01).")
+	}
+	pkt = createPacketEmptyBody(t, "471FFF20")
+	hasPayload, err = pkt.HasPayload()
+	if err != nil {
+		t.Errorf("could not run has payload. error: %s", err.Error())
+		return
+	}
+	if hasPayload {
+		t.Errorf("Packet should not have Payload (AdaptationFieldControl = 10).")
+	}
+	pkt = createPacketEmptyBody(t, "471FFF30")
+	hasPayload, err = pkt.HasPayload()
+	if err != nil {
+		t.Errorf("could not run has payload. error: %s", err.Error())
+		return
+	}
+	if !hasPayload {
+		t.Errorf("Packet should have Payload (AdaptationFieldControl = 11).")
+	}
+}
 
 func TestHeaderComboBasic(t *testing.T) {
 	target := createPacketEmptyBody(t, "47EFA098")
@@ -513,54 +543,54 @@ func TestNilSlicePacket(t *testing.T) {
 	}
 }
 
-// func BenchmarkNewStyleAllFields(b *testing.B) {
-// 	for n := 0; n < b.N; n++ {
-// 		// create everything
-// 		p := NewPacket()
-// 		p.SetContinuityCounter(7)
-// 		p.IncContinuityCounter()
-// 		p.SetPID(4000)
-// 		p.SetTransportErrorIndicator(false)
-// 		p.SetPayloadUnitStartIndicator(true)
-// 		p.SetTransportPriority(false)
-// 		p.SetAdaptationFieldControl(AdaptationFieldFlag)
-// 		p.SetTransportScramblingControl(ScrambleEvenKeyFlag)
-//
-// 		a := p.AdaptationField()
-// 		a.SetHasPCR(true)
-// 		a.SetHasOPCR(true)
-// 		a.SetHasSplicingPoint(true)
-// 		a.SetHasTransportPrivateData(true)
-// 		a.SetHasAdaptationFieldExtension(true)
-// 		a.SetESPriority(true)
-// 		a.SetRandomAccess(true)
-// 		a.SetHasAdaptationFieldExtension(true)
-//
-// 		// read everything
-// 		p.ContinuityCounter()
-// 		p.HasAdaptationField()
-// 		p.HasPayload()
-// 		p.IsNull()
-// 		p.IsPAT()
-// 		p.IsPAT()
-// 		p.PID()
-// 		p.PayloadUnitStartIndicator()
-// 		p.TransportErrorIndicator()
-// 		p.TransportPriority()
-// 		p.TransportScramblingControl()
-//
-// 		a = p.AdaptationField()
-// 		a.Length()
-// 		a.Discontinuity()
-// 		a.ESPriority()
-// 		a.HasAdaptationFieldExtension()
-// 		a.HasOPCR()
-// 		a.HasPCR()
-// 		a.HasSplicingPoint()
-// 		a.HasTransportPrivateData()
-// 		a.RandomAccess()
-// 	}
-// }
+func BenchmarkNewStyleAllFields(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		// create everything
+		p := NewPacket()
+		p.SetContinuityCounter(7)
+		p.IncContinuityCounter()
+		p.SetPID(4000)
+		p.SetTransportErrorIndicator(false)
+		p.SetPayloadUnitStartIndicator(true)
+		p.SetTransportPriority(false)
+		p.SetAdaptationFieldControl(AdaptationFieldFlag)
+		p.SetTransportScramblingControl(ScrambleEvenKeyFlag)
+
+		a, _ := p.AdaptationField()
+		a.SetHasPCR(true)
+		a.SetHasOPCR(true)
+		a.SetHasSplicingPoint(true)
+		a.SetHasTransportPrivateData(true)
+		a.SetHasAdaptationFieldExtension(true)
+		a.SetESPriority(true)
+		a.SetRandomAccess(true)
+		a.SetHasAdaptationFieldExtension(true)
+
+		// read everything
+		p.ContinuityCounter()
+		p.HasAdaptationField()
+		p.HasPayload()
+		p.IsNull()
+		p.IsPAT()
+		p.IsPAT()
+		p.PID()
+		p.PayloadUnitStartIndicator()
+		p.TransportErrorIndicator()
+		p.TransportPriority()
+		p.TransportScramblingControl()
+
+		a, _ = p.AdaptationField()
+		a.Length()
+		a.Discontinuity()
+		a.ESPriority()
+		a.HasAdaptationFieldExtension()
+		a.HasOPCR()
+		a.HasPCR()
+		a.HasSplicingPoint()
+		a.HasTransportPrivateData()
+		a.RandomAccess()
+	}
+}
 
 func BenchmarkNewStyleCreate(b *testing.B) {
 	for n := 0; n < b.N; n++ {

--- a/packet/modify_test.go
+++ b/packet/modify_test.go
@@ -1,0 +1,377 @@
+package packet
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+const (
+	testPacket = "4700001" +
+		"000000000000000000000000000000000000000000000000" +
+		"000000000000000000000000000000000000000000000000" +
+		"000000000000000000000000000000000000000000000000" +
+		"000000000000000000000000000000000000000000000000" +
+		"000000000000000000000000000000000000000000000000" +
+		"000000000000000000000000000000000000000000000000" +
+		"000000000000000000000000000000000000000000000000" +
+		"000000000000000000000000000000000"
+)
+
+func createPacketEmptyBody(t *testing.T, header string) (p Packet) {
+	headerBytes, _ := hex.DecodeString(header)
+	bodyBytes := make([]byte, 188-len(headerBytes))
+	packetByets := Packet(append(headerBytes, bodyBytes...))
+
+	p, err := FromBytes(packetByets)
+	if err != nil {
+		t.Error("packet Error checking failed.")
+	}
+	return
+}
+
+func assertPacket(t *testing.T, target Packet, generated Packet) {
+	if err := target.CheckErrors(); err != nil {
+		t.Error("error in target packet")
+	}
+
+	if err := generated.CheckErrors(); err != nil {
+		t.Error("error in generated packet during modification.")
+	}
+
+	if !target.Equals(generated) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X.", generated, target)
+	}
+}
+
+func TestFromBytes(t *testing.T) {
+	bytes, _ := hex.DecodeString(testPacket)
+	p, err := FromBytes(bytes)
+	if err != nil {
+		t.Error("Packet Error checking failed.")
+	}
+	if (len(bytes) != 188) && (len(p) != 188) {
+		t.Error("Packets are not 188 bytes.")
+		return
+	}
+	for i := range bytes {
+		if bytes[i] != p[i] {
+			t.Error("Packet generated with FromBytes did not copy bytes correctly.")
+			return
+		}
+	}
+}
+
+func TestNewPacket(t *testing.T) {
+	target := createPacketEmptyBody(t, "471FFF10")
+	generated := NewPacket()
+	if err := generated.CheckErrors(); err != nil {
+		t.Error("Default packet has errors.")
+	}
+	assertPacket(t, target, generated)
+}
+
+func TestSetTransportErrorIndicator(t *testing.T) {
+	generated := NewPacket()
+
+	target := createPacketEmptyBody(t, "479FFF10")
+	generated.SetTransportErrorIndicator(true)
+	assertPacket(t, target, generated)
+
+	target = createPacketEmptyBody(t, "471FFF10")
+	generated.SetTransportErrorIndicator(false)
+	assertPacket(t, target, generated)
+}
+
+func TestTransportErrorIndicator(t *testing.T) {
+	pkt := createPacketEmptyBody(t, "479FFF10")
+	if pkt.TransportErrorIndicator() != true {
+		t.Error("Failed to set read set TransportErrorIndicator flag.")
+	}
+}
+
+func TestSetPayloadUnitStartIndicator(t *testing.T) {
+	generated := NewPacket()
+
+	target := createPacketEmptyBody(t, "475FFF10")
+	generated.SetPayloadUnitStartIndicator(true)
+	assertPacket(t, target, generated)
+
+	target = createPacketEmptyBody(t, "471FFF10")
+	generated.SetPayloadUnitStartIndicator(false)
+	assertPacket(t, target, generated)
+}
+
+func TestPayloadUnitStartIndicator(t *testing.T) {
+	pkt := createPacketEmptyBody(t, "475FFF10")
+	if pkt.PayloadUnitStartIndicator() != true {
+		t.Error("Failed to set read set PayloadUnitStartIndicator flag.")
+	}
+}
+
+func TestSetTP(t *testing.T) {
+	generated := NewPacket()
+
+	target := createPacketEmptyBody(t, "473FFF10")
+	generated.SetTransportPriority(true)
+	assertPacket(t, target, generated)
+
+	target = createPacketEmptyBody(t, "471FFF10")
+	generated.SetTransportPriority(false)
+	assertPacket(t, target, generated)
+}
+
+func TestTP(t *testing.T) {
+	pkt := createPacketEmptyBody(t, "473FFF10")
+	if pkt.TransportPriority() != true {
+		t.Error("Failed to set read set TP flag.")
+	}
+}
+
+func TestSetPID(t *testing.T) {
+	generated := createPacketEmptyBody(t, "47e09010")
+
+	target := createPacketEmptyBody(t, "47f76A10")
+	generated.SetPID(0x176A)
+	assertPacket(t, target, generated)
+
+	generated = NewPacket()
+
+	target = createPacketEmptyBody(t, "47000010")
+	generated.SetPID(0x0000)
+	assertPacket(t, target, generated)
+
+	target = createPacketEmptyBody(t, "471fec10")
+	generated.SetPID(0x1fec)
+	assertPacket(t, target, generated)
+}
+
+func TestPID(t *testing.T) {
+	pkt := createPacketEmptyBody(t, "47344410")
+	if pkt.PID() != 0x1444 {
+		t.Errorf("Reads different PID than expected. Expected: %d", 0x1444)
+	}
+}
+
+func TestSetTransportScramblingControl(t *testing.T) {
+	generated := NewPacket()
+
+	target := createPacketEmptyBody(t, "471FFFD0")
+	generated.SetTransportScramblingControl(ScrambleOddKeyFlag)
+	assertPacket(t, target, generated)
+
+	target = createPacketEmptyBody(t, "471FFF90")
+	generated.SetTransportScramblingControl(ScrambleEvenKeyFlag)
+	assertPacket(t, target, generated)
+
+	target = createPacketEmptyBody(t, "471FFF10")
+	generated.SetTransportScramblingControl(NoScrambleFlag)
+	assertPacket(t, target, generated)
+}
+
+func TestTransportScramblingControl(t *testing.T) {
+	pkt := createPacketEmptyBody(t, "471FFF90")
+	if pkt.TransportScramblingControl() != ScrambleEvenKeyFlag {
+		t.Error("Failed to set TransportScramblingControl to ScrambleEvenKeyFlag.")
+	}
+	pkt = createPacketEmptyBody(t, "471FFFD0")
+	if pkt.TransportScramblingControl() != ScrambleOddKeyFlag {
+		t.Error("Failed to set TransportScramblingControl to ScrambleOddKeyFlag.")
+	}
+	pkt = createPacketEmptyBody(t, "471FFF10")
+	if pkt.TransportScramblingControl() != NoScrambleFlag {
+		t.Error("Failed to set TransportScramblingControl to NoScrambleFlag.")
+	}
+}
+
+func TestSetAdaptationFieldControl(t *testing.T) {
+	generated := NewPacket()
+
+	target := createPacketEmptyBody(t, "471FFF10")
+	generated.SetAdaptationFieldControl(PayloadFlag)
+	assertPacket(t, target, generated)
+
+	target = createPacketEmptyBody(t, "471FFF30")
+	generated.SetAdaptationFieldControl(PayloadAndAdaptationFieldFlag)
+	assertPacket(t, target, generated)
+
+	target = createPacketEmptyBody(t, "471FFF20")
+	generated.SetAdaptationFieldControl(AdaptationFieldFlag)
+	assertPacket(t, target, generated)
+}
+
+func TestAdaptationFieldControl(t *testing.T) {
+	pkt := createPacketEmptyBody(t, "471FFF90")
+	if pkt.AdaptationFieldControl() != PayloadFlag {
+		t.Error("Failed to set AdaptationFieldControl to PayloadFlag.")
+	}
+	pkt = createPacketEmptyBody(t, "471FFFB0")
+	if pkt.AdaptationFieldControl() != PayloadAndAdaptationFieldFlag {
+		t.Error("Failed to set AdaptationFieldControl to PayloadAndAdaptationFieldFlag.")
+	}
+	pkt = createPacketEmptyBody(t, "471FFFA0")
+	if pkt.AdaptationFieldControl() != AdaptationFieldFlag {
+		t.Error("Failed to set AdaptationFieldControl to AdaptationFieldFlag.")
+	}
+}
+
+func TestSetContinuityCounter(t *testing.T) {
+	target := createPacketEmptyBody(t, "471FFF1f")
+	generated := NewPacket()
+
+	generated.SetContinuityCounter(15)
+
+	assertPacket(t, target, generated)
+}
+
+func TestContinuityCounterModify(t *testing.T) {
+	pkt := createPacketEmptyBody(t, "471FFF19")
+	if pkt.ContinuityCounter() != 9 {
+		t.Errorf("Reads different ContinuityCounter than expected.")
+	}
+}
+
+func TestIncContinuityCounter(t *testing.T) {
+	target := createPacketEmptyBody(t, "471FFF10")
+	generated := NewPacket()
+
+	generated.SetContinuityCounter(0xFE) // cc = 14
+	generated.IncContinuityCounter()     // cc = 15
+	generated.IncContinuityCounter()     // cc = 0, overflow
+
+	assertPacket(t, target, generated)
+}
+
+func TestIsPAT(t *testing.T) {
+	pkt := createPacketEmptyBody(t, "47000010")
+	if !pkt.IsPAT() {
+		t.Errorf("Packet should be a PAT.")
+	}
+}
+
+func TestIsNull(t *testing.T) {
+	pkt := createPacketEmptyBody(t, "471FFF10")
+	if !pkt.IsNull() {
+		t.Errorf("Packet should be a Null.")
+	}
+}
+
+func TestHasAdaptationField(t *testing.T) {
+	pkt := createPacketEmptyBody(t, "471FFF10")
+	if pkt.HasAdaptationField() {
+		t.Errorf("Packet should not have Adaptation Field (AdaptationFieldControl = 01).")
+	}
+	pkt = createPacketEmptyBody(t, "471FFF20")
+	if !pkt.HasAdaptationField() {
+		t.Errorf("Packet should have Adaptation Field (AdaptationFieldControl = 10).")
+	}
+	pkt = createPacketEmptyBody(t, "471FFF30")
+	if !pkt.HasAdaptationField() {
+		t.Errorf("Packet should have Adaptation Field (AdaptationFieldControl = 11).")
+	}
+}
+
+func TestHasPayload(t *testing.T) {
+	pkt := createPacketEmptyBody(t, "471FFF10")
+	if !pkt.HasPayload() {
+		t.Errorf("Packet should have Payload (AdaptationFieldControl = 01).")
+	}
+	pkt = createPacketEmptyBody(t, "471FFF20")
+	if pkt.HasPayload() {
+		t.Errorf("Packet should not have Payload (AdaptationFieldControl = 10).")
+	}
+	pkt = createPacketEmptyBody(t, "471FFF30")
+	if !pkt.HasPayload() {
+		t.Errorf("Packet should have Payload (AdaptationFieldControl = 11).")
+	}
+}
+
+func TestHeaderComboBasic(t *testing.T) {
+	target := createPacketEmptyBody(t, "47EFA098")
+	generated := NewPacket()
+
+	generated.SetContinuityCounter(7)
+	generated.IncContinuityCounter()
+	generated.SetPID(4000)
+	generated.SetTransportErrorIndicator(true)
+	generated.SetPayloadUnitStartIndicator(true)
+	generated.SetTransportPriority(true)
+	generated.SetAdaptationFieldControl(PayloadFlag)
+	generated.SetTransportScramblingControl(ScrambleEvenKeyFlag)
+
+	assertPacket(t, target, generated)
+
+	if generated.ContinuityCounter() != 8 {
+		t.Errorf("Reads different ContinuityCounter than expected.")
+	}
+	if generated.PID() != 4000 {
+		t.Errorf("Reads different PID than expected.")
+	}
+	if generated.TransportErrorIndicator() != true {
+		t.Errorf("Reads different TransportErrorIndicator than expected.")
+	}
+	if generated.PayloadUnitStartIndicator() != true {
+		t.Errorf("Reads different PayloadUnitStartIndicator than expected.")
+	}
+	if generated.TransportPriority() != true {
+		t.Errorf("Reads different TP than expected.")
+	}
+	if generated.AdaptationFieldControl() != PayloadFlag {
+		t.Errorf("Reads different AdaptationFieldControl than expected.")
+	}
+	if generated.TransportScramblingControl() != ScrambleEvenKeyFlag {
+		t.Errorf("Reads different TransportScramblingControl than expected.")
+	}
+}
+
+func BenchmarkNewStyleCreate(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		pkt := NewPacket()
+		pkt.SetPID(13)
+		pkt.SetAdaptationFieldControl(PayloadFlag)
+		pkt.SetPayloadUnitStartIndicator(true)
+		pkt.SetContinuityCounter(7)
+	}
+}
+
+func BenchmarkOldStyleCreate(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		SetCC(
+			Create(
+				uint16(13),
+				WithHasPayloadFlag,
+				WithPUSI),
+			7)
+	}
+}
+
+func BenchmarkNewStyleRead(b *testing.B) {
+	pkt := NewPacket()
+	pkt.SetPID(13)
+	pkt.SetAdaptationFieldControl(PayloadFlag)
+	pkt.SetPayloadUnitStartIndicator(true)
+	pkt.CheckErrors() // no errors possible
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		pkt.ContinuityCounter()
+		pkt.PayloadUnitStartIndicator()
+		pkt.AdaptationFieldControl()
+		pkt.PID()
+	}
+}
+
+func BenchmarkOldStyleRead(b *testing.B) {
+	pkt := NewPacket()
+	pkt.SetPID(13)
+	pkt.SetAdaptationFieldControl(PayloadFlag)
+	pkt.SetPayloadUnitStartIndicator(true)
+	pkt.CheckErrors() // no errors possible
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		ContinuityCounter(pkt)
+		PayloadUnitStartIndicator(pkt)
+		ContainsPayload(pkt)
+		Pid(pkt)
+	}
+}

--- a/packet/modify_test.go
+++ b/packet/modify_test.go
@@ -18,7 +18,7 @@ const (
 		"000000000000000000000000000000000"
 )
 
-func createPacketEmptyBody(t *testing.T, header string) (p Packet) {
+func createPacketEmptyPayload(t *testing.T, header string) (p Packet) {
 	headerBytes, _ := hex.DecodeString(header)
 	bodyBytes := make([]byte, 188-len(headerBytes))
 	packetBytes := Packet(append(headerBytes, bodyBytes...))
@@ -48,20 +48,6 @@ func createPacketEmptyAdaptationField(t *testing.T, header string) (p Packet) {
 	return
 }
 
-func assertPacket(t *testing.T, target Packet, generated Packet) {
-	if err := target.CheckErrors(); err != nil {
-		t.Error("error in target packet")
-	}
-
-	if err := generated.CheckErrors(); err != nil {
-		t.Error("error in generated packet during modification")
-	}
-
-	if !Equal(generated, target) {
-		t.Errorf("crafted packet:\n%s \ndoes not match expected packet:\n%s.", generated, target)
-	}
-}
-
 func TestFromBytes(t *testing.T) {
 	bytes, _ := hex.DecodeString(testPacket)
 	p, err := FromBytes(bytes)
@@ -81,34 +67,40 @@ func TestFromBytes(t *testing.T) {
 }
 
 func TestNewPacket(t *testing.T) {
-	target := createPacketEmptyBody(t, "471FFF10")
+	target := createPacketEmptyPayload(t, "471FFF10")
 	generated := NewPacket()
 	if err := generated.CheckErrors(); err != nil {
 		t.Error("Default packet has errors.")
 	}
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nCreating a new packet failed.", generated, target)
+	}
 }
 
 func TestSetTransportErrorIndicator(t *testing.T) {
 	generated := NewPacket()
 
-	target := createPacketEmptyBody(t, "479FFF10")
+	target := createPacketEmptyPayload(t, "479FFF10")
 	err := generated.SetTransportErrorIndicator(true)
 	if err != nil {
 		t.Errorf("Failed to set Transport Error indicator: %s", err.Error())
 	}
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the transport error indicator to true has failed.", generated, target)
+	}
 
-	target = createPacketEmptyBody(t, "471FFF10")
+	target = createPacketEmptyPayload(t, "471FFF10")
 	err = generated.SetTransportErrorIndicator(false)
 	if err != nil {
 		t.Errorf("Failed to set Transport Error indicator: %s", err.Error())
 	}
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the transport error indicator to false has failed.", generated, target)
+	}
 }
 
 func TestTransportErrorIndicator(t *testing.T) {
-	pkt := createPacketEmptyBody(t, "479FFF10")
+	pkt := createPacketEmptyPayload(t, "479FFF10")
 	tei, err := pkt.TransportErrorIndicator()
 	if err != nil {
 		t.Error("Failed to read TransportErrorIndicator flag.")
@@ -122,17 +114,21 @@ func TestTransportErrorIndicator(t *testing.T) {
 func TestSetPayloadUnitStartIndicator(t *testing.T) {
 	generated := NewPacket()
 
-	target := createPacketEmptyBody(t, "475FFF10")
+	target := createPacketEmptyPayload(t, "475FFF10")
 	generated.SetPayloadUnitStartIndicator(true)
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the PUSI to true has failed.", generated, target)
+	}
 
-	target = createPacketEmptyBody(t, "471FFF10")
+	target = createPacketEmptyPayload(t, "471FFF10")
 	generated.SetPayloadUnitStartIndicator(false)
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the PUSI to false has failed.", generated, target)
+	}
 }
 
 func TestPayloadUnitStartIndicator(t *testing.T) {
-	pkt := createPacketEmptyBody(t, "475FFF10")
+	pkt := createPacketEmptyPayload(t, "475FFF10")
 	pusi, err := pkt.PayloadUnitStartIndicator()
 	if err != nil {
 		t.Error("Failed to read PayloadUnitStartIndicator flag.")
@@ -146,17 +142,21 @@ func TestPayloadUnitStartIndicator(t *testing.T) {
 func TestSetTP(t *testing.T) {
 	generated := NewPacket()
 
-	target := createPacketEmptyBody(t, "473FFF10")
+	target := createPacketEmptyPayload(t, "473FFF10")
 	generated.SetTransportPriority(true)
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the transport priority to true has failed.", generated, target)
+	}
 
-	target = createPacketEmptyBody(t, "471FFF10")
+	target = createPacketEmptyPayload(t, "471FFF10")
 	generated.SetTransportPriority(false)
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the transport priority to false has failed.", generated, target)
+	}
 }
 
 func TestTP(t *testing.T) {
-	pkt := createPacketEmptyBody(t, "473FFF10")
+	pkt := createPacketEmptyPayload(t, "473FFF10")
 	tp, err := pkt.TransportPriority()
 	if err != nil {
 		t.Error("Failed to read TransportPriority flag.")
@@ -168,25 +168,31 @@ func TestTP(t *testing.T) {
 }
 
 func TestSetPID(t *testing.T) {
-	generated := createPacketEmptyBody(t, "47e09010")
+	generated := createPacketEmptyPayload(t, "47e09010")
 
-	target := createPacketEmptyBody(t, "47f76A10")
+	target := createPacketEmptyPayload(t, "47f76A10")
 	generated.SetPID(0x176A)
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the PID to 0x176A has failed.", generated, target)
+	}
 
 	generated = NewPacket()
 
-	target = createPacketEmptyBody(t, "47000010")
+	target = createPacketEmptyPayload(t, "47000010")
 	generated.SetPID(0x0000)
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the PID to 0x0000 has failed.", generated, target)
+	}
 
-	target = createPacketEmptyBody(t, "471fec10")
+	target = createPacketEmptyPayload(t, "471fec10")
 	generated.SetPID(0x1fec)
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the PID to 0x1fec has failed.", generated, target)
+	}
 }
 
 func TestPID(t *testing.T) {
-	pkt := createPacketEmptyBody(t, "47344410")
+	pkt := createPacketEmptyPayload(t, "47344410")
 	pid, err := pkt.PID()
 	if err != nil {
 		t.Error("failed to read PID")
@@ -200,21 +206,27 @@ func TestPID(t *testing.T) {
 func TestSetTransportScramblingControl(t *testing.T) {
 	generated := NewPacket()
 
-	target := createPacketEmptyBody(t, "471FFFD0")
+	target := createPacketEmptyPayload(t, "471FFFD0")
 	generated.SetTransportScramblingControl(ScrambleOddKeyFlag)
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Transport Scrambling Control to ScrambleOddKeyFlag has failed.", generated, target)
+	}
 
-	target = createPacketEmptyBody(t, "471FFF90")
+	target = createPacketEmptyPayload(t, "471FFF90")
 	generated.SetTransportScramblingControl(ScrambleEvenKeyFlag)
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Transport Scrambling Control to ScrambleEvenKeyFlag has failed.", generated, target)
+	}
 
-	target = createPacketEmptyBody(t, "471FFF10")
+	target = createPacketEmptyPayload(t, "471FFF10")
 	generated.SetTransportScramblingControl(NoScrambleFlag)
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Transport Scrambling Control to NoScrambleFlag has failed.", generated, target)
+	}
 }
 
 func TestTransportScramblingControl(t *testing.T) {
-	pkt := createPacketEmptyBody(t, "471FFF90")
+	pkt := createPacketEmptyPayload(t, "471FFF90")
 	tsc, err := pkt.TransportScramblingControl()
 	if err != nil {
 		t.Error("failed to read transport scrambling control")
@@ -224,7 +236,7 @@ func TestTransportScramblingControl(t *testing.T) {
 		t.Errorf("reads different transport scrambling control than expected. expected: ScrambleEvenKeyFlag")
 	}
 
-	pkt = createPacketEmptyBody(t, "471FFFD0")
+	pkt = createPacketEmptyPayload(t, "471FFFD0")
 	tsc, err = pkt.TransportScramblingControl()
 	if err != nil {
 		t.Error("failed to read transport scrambling control")
@@ -234,7 +246,7 @@ func TestTransportScramblingControl(t *testing.T) {
 		t.Errorf("reads different transport scrambling control than expected. expected: ScrambleOddKeyFlag")
 	}
 
-	pkt = createPacketEmptyBody(t, "471FFF10")
+	pkt = createPacketEmptyPayload(t, "471FFF10")
 	tsc, err = pkt.TransportScramblingControl()
 	if err != nil {
 		t.Error("failed to read transport scrambling control")
@@ -248,21 +260,27 @@ func TestTransportScramblingControl(t *testing.T) {
 func TestSetAdaptationFieldControl(t *testing.T) {
 	generated := NewPacket()
 
-	target := createPacketEmptyBody(t, "471FFF10")
+	target := createPacketEmptyPayload(t, "471FFF10")
 	generated.SetAdaptationFieldControl(PayloadFlag)
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Adaptation Field Control to PayloadFlag has failed.", generated, target)
+	}
 
 	target = createPacketEmptyAdaptationField(t, "471FFF30")
 	generated.SetAdaptationFieldControl(PayloadAndAdaptationFieldFlag)
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Adaptation Field Control to PayloadAndAdaptationFieldFlag has failed.", generated, target)
+	}
 
 	target = createPacketEmptyAdaptationField(t, "471FFF20")
 	generated.SetAdaptationFieldControl(AdaptationFieldFlag)
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Adaptation Field Control to AdaptationFieldFlag has failed.", generated, target)
+	}
 }
 
 func TestAdaptationFieldControl(t *testing.T) {
-	pkt := createPacketEmptyBody(t, "471FFF9000")
+	pkt := createPacketEmptyPayload(t, "471FFF9000")
 	asc, err := pkt.AdaptationFieldControl()
 	if err != nil {
 		t.Error("failed to read adaptation field control")
@@ -292,16 +310,18 @@ func TestAdaptationFieldControl(t *testing.T) {
 }
 
 func TestSetContinuityCounter(t *testing.T) {
-	target := createPacketEmptyBody(t, "471FFF1f")
+	target := createPacketEmptyPayload(t, "471FFF1f")
 	generated := NewPacket()
 
 	generated.SetContinuityCounter(15)
 
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Continuity Counter to 15 has failed.", generated, target)
+	}
 }
 
 func TestContinuityCounterModify(t *testing.T) {
-	pkt := createPacketEmptyBody(t, "471FFF19")
+	pkt := createPacketEmptyPayload(t, "471FFF19")
 	cc, err := pkt.ContinuityCounter()
 	if err != nil {
 		t.Error("failed to read continuity counter")
@@ -313,18 +333,20 @@ func TestContinuityCounterModify(t *testing.T) {
 }
 
 func TestIncContinuityCounter(t *testing.T) {
-	target := createPacketEmptyBody(t, "471FFF10")
+	target := createPacketEmptyPayload(t, "471FFF10")
 	generated := NewPacket()
 
 	generated.SetContinuityCounter(0xFE) // cc = 14
 	generated.IncContinuityCounter()     // cc = 15
 	generated.IncContinuityCounter()     // cc = 0, overflow
 
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nContinuity Counter did not rollover as expected.", generated, target)
+	}
 }
 
 func TestIsPAT(t *testing.T) {
-	pkt := createPacketEmptyBody(t, "47000010")
+	pkt := createPacketEmptyPayload(t, "47000010")
 	isPAT, err := pkt.IsPAT()
 	if err != nil {
 		t.Error("failed to read if packet is a PAT")
@@ -336,7 +358,7 @@ func TestIsPAT(t *testing.T) {
 }
 
 func TestIsNull(t *testing.T) {
-	pkt := createPacketEmptyBody(t, "471FFF10")
+	pkt := createPacketEmptyPayload(t, "471FFF10")
 	isNull, err := pkt.IsNull()
 	if err != nil {
 		t.Error("failed to read if packet is null")
@@ -348,7 +370,7 @@ func TestIsNull(t *testing.T) {
 }
 
 func TestHasAdaptationField(t *testing.T) {
-	pkt := createPacketEmptyBody(t, "471FFF100100")
+	pkt := createPacketEmptyPayload(t, "471FFF100100")
 	hasAF, err := pkt.HasAdaptationField()
 	if err != nil {
 		t.Errorf("could not run has adaptation field. error: %s", err.Error())
@@ -357,7 +379,7 @@ func TestHasAdaptationField(t *testing.T) {
 	if hasAF {
 		t.Errorf("Packet should not have Adaptation Field (AdaptationFieldControl = 01).")
 	}
-	pkt = createPacketEmptyBody(t, "471FFF200100")
+	pkt = createPacketEmptyPayload(t, "471FFF200100")
 	hasAF, err = pkt.HasAdaptationField()
 	if err != nil {
 		t.Errorf("could not run has adaptation field. error: %s", err.Error())
@@ -366,7 +388,7 @@ func TestHasAdaptationField(t *testing.T) {
 	if !hasAF {
 		t.Errorf("Packet should have Adaptation Field (AdaptationFieldControl = 10).")
 	}
-	pkt = createPacketEmptyBody(t, "471FFF300100")
+	pkt = createPacketEmptyPayload(t, "471FFF300100")
 	hasAF, err = pkt.HasAdaptationField()
 	if err != nil {
 		t.Errorf("could not run has adaptation field. error: %s", err.Error())
@@ -378,7 +400,7 @@ func TestHasAdaptationField(t *testing.T) {
 }
 
 func TestHasPayload(t *testing.T) {
-	pkt := createPacketEmptyBody(t, "471FFF10")
+	pkt := createPacketEmptyPayload(t, "471FFF10")
 	hasPayload, err := pkt.HasPayload()
 	if err != nil {
 		t.Errorf("could not run has payload. error: %s", err.Error())
@@ -387,7 +409,7 @@ func TestHasPayload(t *testing.T) {
 	if !hasPayload {
 		t.Errorf("Packet should have Payload (AdaptationFieldControl = 01).")
 	}
-	pkt = createPacketEmptyBody(t, "471FFF20")
+	pkt = createPacketEmptyPayload(t, "471FFF20")
 	hasPayload, err = pkt.HasPayload()
 	if err != nil {
 		t.Errorf("could not run has payload. error: %s", err.Error())
@@ -396,7 +418,7 @@ func TestHasPayload(t *testing.T) {
 	if hasPayload {
 		t.Errorf("Packet should not have Payload (AdaptationFieldControl = 10).")
 	}
-	pkt = createPacketEmptyBody(t, "471FFF30")
+	pkt = createPacketEmptyPayload(t, "471FFF30")
 	hasPayload, err = pkt.HasPayload()
 	if err != nil {
 		t.Errorf("could not run has payload. error: %s", err.Error())
@@ -408,7 +430,7 @@ func TestHasPayload(t *testing.T) {
 }
 
 func TestHeaderComboBasic(t *testing.T) {
-	target := createPacketEmptyBody(t, "47EFA098")
+	target := createPacketEmptyPayload(t, "47EFA098")
 	generated := NewPacket()
 
 	if err := generated.SetContinuityCounter(7); err != nil {
@@ -444,7 +466,9 @@ func TestHeaderComboBasic(t *testing.T) {
 		return
 	}
 
-	assertPacket(t, target, generated)
+	if !Equal(generated, target) {
+		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nFields did not set successfully", generated, target)
+	}
 
 	cc, err := generated.ContinuityCounter()
 	if err != nil {
@@ -506,7 +530,7 @@ func TestHeaderComboBasic(t *testing.T) {
 }
 
 func TestNilSlicePacket(t *testing.T) {
-	//target := createPacketEmptyBody(t, "47EFA098")
+	//target := createPacketEmptyPayload(t, "47EFA098")
 	generated := Packet(nil)
 
 	if err := generated.SetContinuityCounter(7); err != gots.ErrInvalidPacketLength {
@@ -562,7 +586,7 @@ func BenchmarkNewStyleAllFields(b *testing.B) {
 		a.SetHasSplicingPoint(true)
 		a.SetHasTransportPrivateData(true)
 		a.SetHasAdaptationFieldExtension(true)
-		a.SetESPriority(true)
+		a.SetElementaryStreamPriority(true)
 		a.SetRandomAccess(true)
 		a.SetHasAdaptationFieldExtension(true)
 
@@ -582,7 +606,7 @@ func BenchmarkNewStyleAllFields(b *testing.B) {
 		a, _ = p.AdaptationField()
 		a.Length()
 		a.Discontinuity()
-		a.ESPriority()
+		a.ElementaryStreamPriority()
 		a.HasAdaptationFieldExtension()
 		a.HasOPCR()
 		a.HasPCR()

--- a/packet/modify_test.go
+++ b/packet/modify_test.go
@@ -1,3 +1,27 @@
+/*
+MIT License
+
+Copyright 2016 Comcast Cable Communications Management, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 package packet
 
 import (


### PR DESCRIPTION
Gots has the ability to read packets, but its ability to create or modify packets is very limited. Packet creation is an essential feature for writing unit tests. 

Packet type can now use receivers. These changes will not break the existing library interfaces and will remain compatible with old versions of the library. This will be more consistent with the rest of the library (EBP, PSI, PES, SCTE35 all use receivers). Packet creation and modification functionality is added. Almost all fields of the packet can now be read, modified, and created. Error checking was added that checks the packet so it is not corrupted, or in an invalid state.

  
Old way to create packet:

	pkt := SetCC(
		Create(
			uint16(13),
			WithHasPayloadFlag,
			WithPUSI),
		7)

New way to create packet:

    pkt := NewPacket()
    pkt.SetPID(13)
    pkt.SetAdaptationFieldControl(PayloadFlag)
    pkt.SetPayloadUnitStartIndicator(true)
    pkt.SetContinuityCounter(7)