### PR TITLE
PTS simplification

### DIFF
--- a/pts.go
+++ b/pts.go
@@ -89,28 +89,27 @@ func (p PTS) RolledOver(other PTS) bool {
 	return false
 }
 
-// abs is Absolute value. returns magnitude of input.
-func abs(a int64) int64 {
-	if a >= 0 {
-		return a
-	}
-	return -a
-}
-
 // DurationFrom returns the difference between the two pts times.
 // One possible distance has rollover and wraps around the number line,
-// the other one does not wrap around the number line.
-// This function will assume the smallest difference is the correct one.
+// the other one does not wrap around the number line and doesn't have rollover.
+// DurationFrom will assume the smallest difference is the correct one.
 // This number is always positive.
+// This function will only be accurate if the difference between the two
+// PTS values is less than MaxPtsTicks/2 (2^32 = 4294967296 = 0x100000000)
 func (p PTS) DurationFrom(from PTS) PTS {
+	var difference PTS
 	if p == PtsPositiveInfinity || p == PtsNegativeInfinity || from == PtsPositiveInfinity || from == PtsNegativeInfinity {
 		return PtsPositiveInfinity
 	}
-	difference := abs(int64(p) - int64(from))
+	if p > from {
+		difference = p - from
+	} else {
+		difference = from - p
+	}
 	if difference >= MaxPtsTicks/2 {
 		difference = MaxPtsTicks - difference
 	}
-	return PTS(difference)
+	return difference
 }
 
 // Add adds the two PTS times together and returns a new PTS

--- a/pts.go
+++ b/pts.go
@@ -89,27 +89,18 @@ func (p PTS) RolledOver(other PTS) bool {
 	return false
 }
 
-// DurationFrom returns the difference between the two pts times.
-// One possible distance has rollover and wraps around the number line,
-// the other one does not wrap around the number line and doesn't have rollover.
-// DurationFrom will assume the smallest difference is the correct one.
-// This number is always positive.
-// This function will only be accurate if the difference between the two
-// PTS values is less than MaxPtsTicks/2 (2^32 = 4294967296 = 0x100000000)
-func (p PTS) DurationFrom(from PTS) PTS {
-	var difference PTS
-	if p == PtsPositiveInfinity || p == PtsNegativeInfinity || from == PtsPositiveInfinity || from == PtsNegativeInfinity {
-		return PtsPositiveInfinity
+// DurationFrom returns the difference between the two pts times. This number is always positive.
+func (p PTS) DurationFrom(from PTS) uint64 {
+	switch {
+	case p.RolledOver(from):
+		return uint64((MaxPtsTicks - from) + p)
+	case from.RolledOver(p):
+		return uint64((MaxPtsTicks - p) + from)
+	case p < from:
+		return uint64(from - p)
+	default:
+		return uint64(p - from)
 	}
-	if p > from {
-		difference = p - from
-	} else {
-		difference = from - p
-	}
-	if difference >= MaxPtsTicks/2 {
-		difference = MaxPtsTicks - difference
-	}
-	return difference
 }
 
 // Add adds the two PTS times together and returns a new PTS

--- a/pts.go
+++ b/pts.go
@@ -33,10 +33,10 @@ const (
 	PTS_DTS_INDICATOR_NONE     = 0 // 00
 
 	// MaxPtsValue is the highest value the PTS can hold before it rolls over, since its a 33 bit timestamp.
-	MaxPtsValue = 8589934591 // 2^33 - 1
+	MaxPtsValue = (1 << 33) - 1 // 2^33 - 1 = 8589934591 = 0x1FFFFFFFF
 
 	// MaxPtsTicks is the length of the complete PTS timeline.
-	MaxPtsTicks = 8589934592 // 2^33.
+	MaxPtsTicks = 1 << 33 // 2^33 = 8589934592 = 0x200000000
 
 	// Used as a sentinel values for algorithms working against PTS
 	PtsNegativeInfinity = PTS(math.MaxUint64 - 1) //18446744073709551614
@@ -89,27 +89,33 @@ func (p PTS) RolledOver(other PTS) bool {
 	return false
 }
 
-// DurationFrom returns the difference between the two pts times. This number is always positive.
-func (p PTS) DurationFrom(from PTS) uint64 {
-	switch {
-	case p.RolledOver(from):
-		return uint64((MaxPtsTicks - from) + p)
-	case from.RolledOver(p):
-		return uint64((MaxPtsTicks - p) + from)
-	case p < from:
-		return uint64(from - p)
-	default:
-		return uint64(p - from)
+// abs is Absolute value. returns magnitude of input.
+func abs(a int64) int64 {
+	if a >= 0 {
+		return a
 	}
+	return -a
+}
+
+// DurationFrom returns the difference between the two pts times.
+// One possible distance has rollover and wraps around the number line,
+// the other one does not wrap around the number line.
+// This function will assume the smallest difference is the correct one.
+// This number is always positive.
+func (p PTS) DurationFrom(from PTS) PTS {
+	if p == PtsPositiveInfinity || p == PtsNegativeInfinity || from == PtsPositiveInfinity || from == PtsNegativeInfinity {
+		return PtsPositiveInfinity
+	}
+	difference := abs(int64(p) - int64(from))
+	if difference >= MaxPtsTicks/2 {
+		difference = MaxPtsTicks - difference
+	}
+	return PTS(difference)
 }
 
 // Add adds the two PTS times together and returns a new PTS
 func (p PTS) Add(x PTS) PTS {
-	result := p + x
-	if result > MaxPtsValue {
-		result = result - MaxPtsTicks
-	}
-	return PTS(result)
+	return (p + x) & MaxPtsValue
 }
 
 // ExtractTime extracts a PTS time

--- a/pts_test.go
+++ b/pts_test.go
@@ -124,6 +124,10 @@ func TestAdd(t *testing.T) {
 	if PTS(2000) != PTS(1500).Add(PTS(500)) {
 		t.Error("PTS addition 2 test failed")
 	}
+	// both of these values cannot fit in 33 bits
+	if PTS(0x187654321) != PTS(0x2E00000000).Add(PTS(0x5587654321)) {
+		t.Error("PTS addition 3 test failed")
+	}
 }
 
 func TestInsertPTS(t *testing.T) {

--- a/pts_test.go
+++ b/pts_test.go
@@ -93,14 +93,6 @@ func TestPTSDurationFrom(t *testing.T) {
 	if 16 != PTS(5).DurationFrom(PTS(MaxPtsValue-10)) {
 		t.Error("Expected duration of 16")
 	}
-
-	if 0x011111111 != PTS(MaxPtsTicks-0x010000000).DurationFrom(PTS(0x001111111)) {
-		t.Error("Expected duration of 0x011111111")
-	}
-
-	if PtsPositiveInfinity != PTS(0x110000000).DurationFrom(PtsPositiveInfinity) {
-		t.Error("Expected duration of PtsPositiveInfinity")
-	}
 }
 
 func TestPTSGreaterOrEqual(t *testing.T) {

--- a/pts_test.go
+++ b/pts_test.go
@@ -93,6 +93,14 @@ func TestPTSDurationFrom(t *testing.T) {
 	if 16 != PTS(5).DurationFrom(PTS(MaxPtsValue-10)) {
 		t.Error("Expected duration of 16")
 	}
+
+	if 0x011111111 != PTS(MaxPtsTicks-0x010000000).DurationFrom(PTS(0x001111111)) {
+		t.Error("Expected duration of 0x011111111")
+	}
+
+	if PtsPositiveInfinity != PTS(0x110000000).DurationFrom(PtsPositiveInfinity) {
+		t.Error("Expected duration of PtsPositiveInfinity")
+	}
 }
 
 func TestPTSGreaterOrEqual(t *testing.T) {


### PR DESCRIPTION
PTS constants were simplified.

PTS Add was changed to use a bit mask instead of conditional subtraction. This is done to improve performance and shorten the logic.

PTS DurationFrom was changed to not use rollover thresholds. Instead, it will return the difference that accounts for rollover if it is shorter than the one that does not account for rollover. The return type for DurationFrom was changed from a uint64 to a PTS. DurationFrom now works with infinity.