### PR TITLE
EBP creation

### DIFF
--- a/ebp/cablelabsebp.go
+++ b/ebp/cablelabsebp.go
@@ -25,6 +25,7 @@ SOFTWARE.
 package ebp
 
 import (
+	"bytes"
 	"encoding/binary"
 	"io"
 	"time"
@@ -45,52 +46,125 @@ type cableLabsEbp struct {
 	SuccessReadTime  time.Time
 }
 
-func (ebp cableLabsEbp) EBPType() byte {
+func CreateCableLabsEbp() cableLabsEbp {
+	return cableLabsEbp{
+		DataFieldTag:     CableLabsEbpTag,
+		DataFieldLength:  1, // not empty by default
+		FormatIdentifier: CableLabsFormatIdentifier,
+	}
+}
+
+func (ebp *cableLabsEbp) EBPType() byte {
 	return ebp.DataFieldTag
 }
 
-func (ebp cableLabsEbp) FragmentFlag() bool {
+func (ebp *cableLabsEbp) FragmentFlag() bool {
 	return ebp.DataFlags&0x80 != 0
 }
 
-func (ebp cableLabsEbp) SegmentFlag() bool {
+func (ebp *cableLabsEbp) SetFragmentFlag(value bool) {
+	if ebp.DataFieldLength != 0 && value {
+		ebp.DataFlags |= 0x80
+	}
+}
+
+func (ebp *cableLabsEbp) SegmentFlag() bool {
 	return ebp.DataFlags&0x40 != 0
 }
 
-func (ebp cableLabsEbp) SapFlag() bool {
+func (ebp *cableLabsEbp) SetSegmentFlag(value bool) {
+	if ebp.DataFieldLength != 0 && value {
+		ebp.DataFlags |= 0x40
+	}
+}
+
+func (ebp *cableLabsEbp) SapFlag() bool {
 	return ebp.DataFlags&0x20 != 0
 }
 
-func (ebp cableLabsEbp) GroupingFlag() bool {
+func (ebp *cableLabsEbp) SetSapFlag(value bool) {
+	if ebp.DataFieldLength != 0 && value {
+		ebp.DataFlags |= 0x20
+	}
+}
+
+func (ebp *cableLabsEbp) GroupingFlag() bool {
 	return ebp.DataFlags&0x10 != 0
 }
 
-func (ebp cableLabsEbp) TimeFlag() bool {
+func (ebp *cableLabsEbp) SetGroupingFlag(value bool) {
+	if ebp.DataFieldLength != 0 && value {
+		ebp.DataFlags |= 0x10
+	}
+}
+
+func (ebp *cableLabsEbp) GroupingIDs() []uint8 {
+	return ebp.Grouping
+}
+
+func (ebp *cableLabsEbp) SetGroupingIDs(values []uint8) {
+	ebp.Grouping = make([]uint8, len(values))
+	for i := range ebp.Grouping {
+		ebp.Grouping[i] = values[i]
+		ebp.Grouping[i] |= 0x80
+		if i == len(ebp.Grouping)-1 {
+			ebp.Grouping[i] &= 0x7F // last index does not have this flag set
+		}
+	}
+}
+
+func (ebp *cableLabsEbp) TimeFlag() bool {
 	return ebp.DataFlags&0x08 != 0
 }
 
-func (ebp cableLabsEbp) ConcealmentFlag() bool {
+func (ebp *cableLabsEbp) SetTimeFlag(value bool) {
+	if ebp.DataFieldLength != 0 && value {
+		ebp.DataFlags |= 0x08
+	}
+}
+
+func (ebp *cableLabsEbp) ConcealmentFlag() bool {
 	return ebp.DataFlags&0x04 != 0
 }
 
-func (ebp cableLabsEbp) ExtensionFlag() bool {
+func (ebp *cableLabsEbp) SetConcealmentFlag(value bool) {
+	if ebp.DataFieldLength != 0 && value {
+		ebp.DataFlags |= 0x04
+	}
+}
+
+func (ebp *cableLabsEbp) ExtensionFlag() bool {
 	return ebp.DataFlags&0x01 != 0
 }
 
-func (ebp cableLabsEbp) EBPTime() time.Time {
+func (ebp *cableLabsEbp) SetExtensionFlag(value bool) {
+	if ebp.DataFieldLength != 0 && value {
+		ebp.DataFlags |= 0x01
+	}
+}
+
+func (ebp *cableLabsEbp) EBPTime() time.Time {
 	return extractUtcTime(ebp.TimeSeconds, ebp.TimeFraction)
 }
 
-func (ebp cableLabsEbp) Sap() byte {
+func (ebp *cableLabsEbp) SetEBPTime(t time.Time) {
+	insertUtcTime(t, &ebp.TimeSeconds, &ebp.TimeFraction)
+}
+
+func (ebp *cableLabsEbp) Sap() byte {
 	return ebp.SapType
 }
 
-func (ebp cableLabsEbp) PartitionFlag() bool {
+func (ebp *cableLabsEbp) SetSap(sapType byte) {
+	ebp.SapType = sapType
+}
+
+func (ebp *cableLabsEbp) PartitionFlag() bool {
 	return ebp.ExtensionFlag() && ebp.ExtensionFlags&0x80 != 0
 }
 
 // Defines when the EBP was read successfully
-func (ebp cableLabsEbp) EBPSuccessReadTime() time.Time {
+func (ebp *cableLabsEbp) EBPSuccessReadTime() time.Time {
 	return ebp.SuccessReadTime
 }
 
@@ -173,4 +247,50 @@ func readCableLabsEbp(data io.Reader) (ebp *cableLabsEbp, err error) {
 	ebp.SuccessReadTime = time.Now()
 
 	return ebp, nil
+}
+
+// Data will return the raw bytes of the EBP
+func (ebp *cableLabsEbp) Data() []byte {
+	requiredFields := new(bytes.Buffer)
+	data := new(bytes.Buffer)
+	binary.Write(requiredFields, ebpEncoding, ebp.DataFieldTag)
+
+	if ebp.DataFieldLength == 0 {
+		return data.Bytes()
+	}
+
+	binary.Write(data, ebpEncoding, ebp.FormatIdentifier)
+
+	binary.Write(data, ebpEncoding, ebp.DataFlags)
+	if ebp.ExtensionFlag() {
+		binary.Write(data, ebpEncoding, ebp.ExtensionFlags)
+	}
+
+	if ebp.SapFlag() {
+		binary.Write(data, ebpEncoding, ebp.SapType)
+	}
+
+	if ebp.GroupingFlag() {
+		for i := range ebp.Grouping {
+			binary.Write(data, ebpEncoding, ebp.Grouping[i])
+		}
+	}
+
+	if ebp.TimeFlag() {
+		binary.Write(data, ebpEncoding, ebp.TimeSeconds)
+		binary.Write(data, ebpEncoding, ebp.TimeFraction)
+	}
+
+	if ebp.PartitionFlag() {
+		binary.Write(data, ebpEncoding, ebp.PartitionFlags)
+	}
+
+	binary.Write(data, ebpEncoding, ebp.ReservedBytes)
+
+	ebp.DataFieldLength = uint8(data.Len())
+
+	binary.Write(requiredFields, ebpEncoding, ebp.DataFieldLength)
+	binary.Write(requiredFields, ebpEncoding, data.Bytes())
+
+	return requiredFields.Bytes()
 }

--- a/ebp/cablelabsebp.go
+++ b/ebp/cablelabsebp.go
@@ -46,6 +46,7 @@ type cableLabsEbp struct {
 	SuccessReadTime  time.Time
 }
 
+// CreateCableLabsEbp returns a new cableLabsEbp with default values.
 func CreateCableLabsEbp() cableLabsEbp {
 	return cableLabsEbp{
 		DataFieldTag:     CableLabsEbpTag,
@@ -54,103 +55,138 @@ func CreateCableLabsEbp() cableLabsEbp {
 	}
 }
 
+// EBPtype returns the type (what is the format) of the EBP.
 func (ebp *cableLabsEbp) EBPType() byte {
 	return ebp.DataFieldTag
 }
 
+// FragmentFlag returns true if the fragment flag is set.
 func (ebp *cableLabsEbp) FragmentFlag() bool {
 	return ebp.DataFlags&0x80 != 0
 }
 
+// SetFragmentFlag sets the fragment flag.
 func (ebp *cableLabsEbp) SetFragmentFlag(value bool) {
 	if ebp.DataFieldLength != 0 && value {
 		ebp.DataFlags |= 0x80
 	}
 }
 
+// SegmentFlag returns true if the segment flag is set.
 func (ebp *cableLabsEbp) SegmentFlag() bool {
 	return ebp.DataFlags&0x40 != 0
 }
 
+// SetSegmentFlag sets the segment flag.
 func (ebp *cableLabsEbp) SetSegmentFlag(value bool) {
 	if ebp.DataFieldLength != 0 && value {
 		ebp.DataFlags |= 0x40
 	}
 }
 
+// SapFlag returns true if the sap flag is set.
 func (ebp *cableLabsEbp) SapFlag() bool {
 	return ebp.DataFlags&0x20 != 0
 }
 
+// SetSapFlag sets the sap flag.
 func (ebp *cableLabsEbp) SetSapFlag(value bool) {
 	if ebp.DataFieldLength != 0 && value {
 		ebp.DataFlags |= 0x20
 	}
 }
 
+// GroupingFlag returns true if the grouping flag is set.
 func (ebp *cableLabsEbp) GroupingFlag() bool {
 	return ebp.DataFlags&0x10 != 0
 }
 
+// SetGroupingFlag sets the grouping flag.
 func (ebp *cableLabsEbp) SetGroupingFlag(value bool) {
 	if ebp.DataFieldLength != 0 && value {
 		ebp.DataFlags |= 0x10
 	}
 }
 
+// TimeFlag returns true if the time flag is set.
 func (ebp *cableLabsEbp) TimeFlag() bool {
 	return ebp.DataFlags&0x08 != 0
 }
 
+// SetTimeFlag sets the time flag
 func (ebp *cableLabsEbp) SetTimeFlag(value bool) {
 	if ebp.DataFieldLength != 0 && value {
 		ebp.DataFlags |= 0x08
 	}
 }
 
+// ConcealmentFlag returns true if the concealment flag is set.
 func (ebp *cableLabsEbp) ConcealmentFlag() bool {
 	return ebp.DataFlags&0x04 != 0
 }
 
+// SetConcealmentFlag sets the concealment flag.
 func (ebp *cableLabsEbp) SetConcealmentFlag(value bool) {
 	if ebp.DataFieldLength != 0 && value {
 		ebp.DataFlags |= 0x04
 	}
 }
 
+// ExtensionFlag returns true if the extension flag is set.
 func (ebp *cableLabsEbp) ExtensionFlag() bool {
 	return ebp.DataFlags&0x01 != 0
 }
 
+// SetExtensionFlag sets the extension flag.
 func (ebp *cableLabsEbp) SetExtensionFlag(value bool) {
 	if ebp.DataFieldLength != 0 && value {
 		ebp.DataFlags |= 0x01
 	}
 }
 
+// EBPTime returns the EBP time as a UTC time.
 func (ebp *cableLabsEbp) EBPTime() time.Time {
 	return extractUtcTime(ebp.TimeSeconds, ebp.TimeFraction)
 }
 
+// SetEBPTime sets the time of the EBP. Takes UTC time as an input.
 func (ebp *cableLabsEbp) SetEBPTime(t time.Time) {
 	ebp.TimeSeconds, ebp.TimeFraction = insertUtcTime(t)
 }
 
+// Sap returns the sap of the EBP.
 func (ebp *cableLabsEbp) Sap() byte {
 	return ebp.SapType
 }
 
+// SetSap sets the sap of the EBP.
 func (ebp *cableLabsEbp) SetSap(sapType byte) {
 	ebp.SapType = sapType
 }
 
+// SetPartitionFlag returns true if the partition flag.
 func (ebp *cableLabsEbp) PartitionFlag() bool {
 	return ebp.ExtensionFlag() && ebp.ExtensionFlags&0x80 != 0
 }
 
+// SetPartitionFlag sets the partition flag.
 func (ebp *cableLabsEbp) SetPartitionFlag(value bool) {
 	if ebp.ExtensionFlag() && value {
 		ebp.ExtensionFlags |= 0x80
+	}
+}
+
+// IsEmpty returns if the EBP is empty (zero length)
+func (ebp *cableLabsEbp) IsEmpty() bool {
+	return ebp.DataFieldLength == 0
+}
+
+// SetIsEmpty sets if the EBP is empty (zero length)
+func (ebp *cableLabsEbp) SetIsEmpty(value bool) {
+	if value {
+		ebp.DataFieldLength = 0
+	} else {
+		ebp.DataFieldLength = 1
 	}
 }
 

--- a/ebp/cablelabsebp_test.go
+++ b/ebp/cablelabsebp_test.go
@@ -89,11 +89,11 @@ func TestCableLabsEBP(t *testing.T) {
 	ebp.SetFragmentFlag(true)
 	ebp.SetConcealmentFlag(true)
 	ebp.SetExtensionFlag(true)
-	ebp.ExtensionFlags = 0x80 // TODO
+	ebp.SetPartitionFlag(true)
 	ebp.SetSapFlag(true)
-	ebp.SetSap(0x02)
+	ebp.SapType = 0x02
 	ebp.SetGroupingFlag(true)
-	ebp.Grouping = []byte{0xFF, 0x7F}
+	ebp.Grouping = []byte{0x7F, 0xFF} // wrong on purpose, will be corrected to 0xFF, 0x7F
 	ebp.SetTimeFlag(true)
 	ebp.SetEBPTime(time.Unix(0, 1396964696553818999).UTC())
 	ebp.PartitionFlags = 0x03

--- a/ebp/cablelabsebp_test.go
+++ b/ebp/cablelabsebp_test.go
@@ -82,3 +82,28 @@ func TestParseCableLabsEBP(t *testing.T) {
 		t.Errorf("readCableLabsEbp() returned not null EBP on invalid EBP")
 	}
 }
+
+func TestCableLabsEBP(t *testing.T) {
+	expected := CableLabsEBPBytes
+	ebp := CreateCableLabsEbp()
+	ebp.SetFragmentFlag(true)
+	ebp.SetConcealmentFlag(true)
+	ebp.SetExtensionFlag(true)
+	ebp.ExtensionFlags = 0x80 // TODO
+	ebp.SetSapFlag(true)
+	ebp.SetSap(0x02)
+	ebp.SetGroupingFlag(true)
+	ebp.Grouping = []byte{0xFF, 0x7F}
+	ebp.SetTimeFlag(true)
+	ebp.SetEBPTime(time.Unix(0, 1396964696553818999).UTC())
+	ebp.PartitionFlags = 0x03
+	ebp.ReservedBytes = []byte{0x04, 0x05}
+
+	generated := ebp.Data()
+	if !bytes.Equal(generated, expected) {
+		t.Errorf("Data() does not produce expected raw data\nExpected: %X\n     Got: %X",
+			expected,
+			generated,
+		)
+	}
+}

--- a/ebp/comcastebp.go
+++ b/ebp/comcastebp.go
@@ -233,38 +233,31 @@ func (ebp *comcastEbp) Data() []byte {
 		return data.Bytes()
 	}
 
-	ebp.DataFieldLength = 0
-
 	binary.Write(data, ebpEncoding, ebp.DataFlags)
-	ebp.DataFieldLength += uint8(1)
+
 	if ebp.ExtensionFlag() {
 		binary.Write(data, ebpEncoding, ebp.ExtensionFlags)
-		ebp.DataFieldLength += uint8(1)
 	}
 
 	if ebp.SapFlag() {
 		binary.Write(data, ebpEncoding, ebp.SapType)
-		ebp.DataFieldLength += uint8(1)
 	}
 
 	if ebp.GroupingFlag() {
 		binary.Write(data, ebpEncoding, ebp.Grouping)
-		ebp.DataFieldLength += uint8(1)
 	}
 
 	if ebp.TimeFlag() {
 		binary.Write(data, ebpEncoding, ebp.TimeSeconds)
 		binary.Write(data, ebpEncoding, ebp.TimeFraction)
-		ebp.DataFieldLength += uint8(8)
 	}
 
 	binary.Write(data, ebpEncoding, ebp.ReservedBytes)
-	ebp.DataFieldLength += uint8(len(ebp.ReservedBytes))
 
-	dataBytes := data.Bytes()
+	ebp.DataFieldLength = uint8(data.Len())
 
-	binary.Write(requiredFields, ebpEncoding, byte(len(dataBytes)))
-	binary.Write(requiredFields, ebpEncoding, dataBytes)
+	binary.Write(requiredFields, ebpEncoding, ebp.DataFieldLength)
+	binary.Write(requiredFields, ebpEncoding, data.Bytes())
 
 	return requiredFields.Bytes()
 }

--- a/ebp/comcastebp.go
+++ b/ebp/comcastebp.go
@@ -130,7 +130,7 @@ func (ebp *comcastEbp) EBPTime() time.Time {
 }
 
 func (ebp *comcastEbp) SetEBPTime(t time.Time) {
-	insertUtcTime(t, &ebp.TimeSeconds, &ebp.TimeFraction)
+	ebp.TimeSeconds, ebp.TimeFraction = insertUtcTime(t)
 }
 
 func (ebp *comcastEbp) Sap() byte {

--- a/ebp/comcastebp.go
+++ b/ebp/comcastebp.go
@@ -44,6 +44,7 @@ type comcastEbp struct {
 	SuccessReadTime time.Time
 }
 
+// CreateComcastEBP returns a new comcastEbp with default values.
 func CreateComcastEBP() comcastEbp {
 	return comcastEbp{
 		DataFieldTag:    ComcastEbpTag,
@@ -51,100 +52,121 @@ func CreateComcastEBP() comcastEbp {
 	}
 }
 
+// EBPtype returns the type (what is the format) of the EBP.
 func (ebp *comcastEbp) EBPType() byte {
 	return ebp.DataFieldTag
 }
 
+// FragmentFlag returns true if the fragment flag is set.
 func (ebp *comcastEbp) FragmentFlag() bool {
 	return ebp.DataFieldLength != 0 && ebp.DataFlags&0x80 != 0
 }
 
+// SetFragmentFlag sets the fragment flag.
 func (ebp *comcastEbp) SetFragmentFlag(value bool) {
 	if ebp.DataFieldLength != 0 && value {
 		ebp.DataFlags |= 0x80
 	}
 }
 
+// SegmentFlag returns true if the segment flag is set.
 func (ebp *comcastEbp) SegmentFlag() bool {
 	return ebp.DataFieldLength != 0 && ebp.DataFlags&0x40 != 0
 }
 
+// SetSegmentFlag sets the segment flag.
 func (ebp *comcastEbp) SetSegmentFlag(value bool) {
 	if ebp.DataFieldLength != 0 && value {
 		ebp.DataFlags |= 0x40
 	}
 }
 
+// SapFlag returns true if the sap flag is set.
 func (ebp *comcastEbp) SapFlag() bool {
 	return ebp.DataFieldLength != 0 && ebp.DataFlags&0x20 != 0
 }
 
+// SetSapFlag sets the sap flag.
 func (ebp *comcastEbp) SetSapFlag(value bool) {
 	if ebp.DataFieldLength != 0 && value {
 		ebp.DataFlags |= 0x20
 	}
 }
 
+// GroupingFlag returns true if the grouping flag is set.
 func (ebp *comcastEbp) GroupingFlag() bool {
 	return ebp.DataFieldLength != 0 && ebp.DataFlags&0x10 != 0
 }
 
+// SetGroupingFlag sets the grouping flag.
 func (ebp *comcastEbp) SetGroupingFlag(value bool) {
 	if ebp.DataFieldLength != 0 && value {
 		ebp.DataFlags |= 0x10
 	}
 }
 
+// TimeFlag returns true if the time flag is set.
 func (ebp *comcastEbp) TimeFlag() bool {
 	return ebp.DataFieldLength != 0 && ebp.DataFlags&0x08 != 0
 }
 
+// SetTimeFlag sets the time flag
 func (ebp *comcastEbp) SetTimeFlag(value bool) {
 	if ebp.DataFieldLength != 0 && value {
 		ebp.DataFlags |= 0x08
 	}
 }
 
+// DiscontinuityFlag returns true if the discontinuity flag is set.
 func (ebp *comcastEbp) DiscontinuityFlag() bool {
 	return ebp.DataFieldLength != 0 && ebp.DataFlags&0x04 != 0
 }
 
+// SetDiscontinuityFlag sets the discontinuity flag.
 func (ebp *comcastEbp) SetDiscontinuityFlag(value bool) {
 	if ebp.DataFieldLength != 0 && value {
 		ebp.DataFlags |= 0x04
 	}
 }
 
+// ExtensionFlag returns true if the extension flag is set.
 func (ebp *comcastEbp) ExtensionFlag() bool {
 	return ebp.DataFieldLength != 0 && ebp.DataFlags&0x01 != 0
 }
 
+// SetExtensionFlag sets the extension flag.
 func (ebp *comcastEbp) SetExtensionFlag(value bool) {
 	if ebp.DataFieldLength != 0 && value {
 		ebp.DataFlags |= 0x01
 	}
 }
 
+// EBPTime returns the EBP time as a UTC time.
 func (ebp *comcastEbp) EBPTime() time.Time {
 	return extractUtcTime(ebp.TimeSeconds, ebp.TimeFraction)
 }
 
+// SetEBPTime sets the time of the EBP. Takes UTC time as an input.
 func (ebp *comcastEbp) SetEBPTime(t time.Time) {
 	ebp.TimeSeconds, ebp.TimeFraction = insertUtcTime(t)
 }
 
+// Sap returns the sap of the EBP.
 func (ebp *comcastEbp) Sap() byte {
 	return ebp.SapType
 }
 
+// SetSap sets the sap of the EBP.
 func (ebp *comcastEbp) SetSap(sapType byte) {
 	ebp.SapType = sapType
 }
 
-func (ebp *comcastEbp) isEmpty() bool {
+// IsEmpty returns if the EBP is empty (zero length)
+func (ebp *comcastEbp) IsEmpty() bool {
 	return ebp.DataFieldLength == 0
 }
 
+// SetIsEmpty sets if the EBP is empty (zero length)
 func (ebp *comcastEbp) SetIsEmpty(value bool) {
 	if value {
 		ebp.DataFieldLength = 0
@@ -153,7 +175,7 @@ func (ebp *comcastEbp) SetIsEmpty(value bool) {
 	}
 }
 
-// Defines when the EBP was read successfully
+// EBPSuccessReadTime defines when the EBP was read successfully.
 func (ebp *comcastEbp) EBPSuccessReadTime() time.Time {
 	return ebp.SuccessReadTime
 }

--- a/ebp/comcastebp_test.go
+++ b/ebp/comcastebp_test.go
@@ -99,7 +99,7 @@ func TestCreateComcastEBP(t *testing.T) {
 	ebp.SetExtensionFlag(true)
 	ebp.ExtensionFlags = 0x01
 	ebp.SetSapFlag(true)
-	ebp.SetSap(0x02)
+	ebp.SapType = 0x02
 	ebp.SetGroupingFlag(true)
 	ebp.Grouping = 0x03
 	ebp.SetTimeFlag(true)

--- a/ebp/comcastebp_test.go
+++ b/ebp/comcastebp_test.go
@@ -90,3 +90,27 @@ func TestParseComcastEBP(t *testing.T) {
 		t.Errorf("readComcastEbp() returned not null EBP on invalid EBP")
 	}
 }
+
+func TestCreateComcastEBP(t *testing.T) {
+	expected := ComcastEBPBytes
+	ebp := CreateComcastEBP()
+	ebp.SetFragmentFlag(true)
+	ebp.SetDiscontinuityFlag(true)
+	ebp.SetExtensionFlag(true)
+	ebp.ExtensionFlags = 0x01
+	ebp.SetSapFlag(true)
+	ebp.SetSap(0x02)
+	ebp.SetGroupingFlag(true)
+	ebp.Grouping = 0x03
+	ebp.SetTimeFlag(true)
+	ebp.SetEBPTime(time.Unix(0, 1396964696553818999).UTC())
+	ebp.ReservedBytes = []byte{0x04, 0x05}
+
+	generated := ebp.Data()
+	if !bytes.Equal(generated, expected) {
+		t.Errorf("Data() does not produce expected raw data\nExpected: %X\n     Got: %X",
+			expected,
+			generated,
+		)
+	}
+}

--- a/ebp/doc.go
+++ b/ebp/doc.go
@@ -42,6 +42,7 @@ type EncoderBoundaryPoint interface {
 	SetFragmentFlag(bool)
 	TimeFlag() bool
 	SetTimeFlag(bool)
+	GroupingFlag() bool
 	EBPTime() time.Time // time set in the EBP
 	SetEBPTime(time.Time)
 	EBPSuccessReadTime() time.Time // time the EBP was successfully read

--- a/ebp/doc.go
+++ b/ebp/doc.go
@@ -37,12 +37,20 @@ const (
 // EncoderBoundaryPoint represents shared operations available on an all EBPs.
 type EncoderBoundaryPoint interface {
 	SegmentFlag() bool
+	SetSegmentFlag(bool)
 	FragmentFlag() bool
+	SetFragmentFlag(bool)
 	TimeFlag() bool
-	EBPTime() time.Time            // time set in the EBP
+	SetTimeFlag(bool)
+	EBPTime() time.Time // time set in the EBP
+	SetEBPTime(time.Time)
 	EBPSuccessReadTime() time.Time // time the EBP was successfully read
 	SapFlag() bool
+	SetSapFlag(bool)
 	Sap() byte
+	SetSap(byte)
 	ExtensionFlag() bool
+	SetExtensionFlag(bool)
 	EBPType() byte
+	Data() []byte
 }

--- a/ebp/doc.go
+++ b/ebp/doc.go
@@ -36,22 +36,46 @@ const (
 
 // EncoderBoundaryPoint represents shared operations available on an all EBPs.
 type EncoderBoundaryPoint interface {
+	// SegmentFlag returns true if the segment flag is set.
 	SegmentFlag() bool
+	// SetSegmentFlag sets the segment flag.
 	SetSegmentFlag(bool)
+	// FragmentFlag returns true if the fragment flag is set.
 	FragmentFlag() bool
+	// SetFragmentFlag sets the fragment flag.
 	SetFragmentFlag(bool)
+	// TimeFlag returns true if the time flag is set.
 	TimeFlag() bool
+	// SetTimeFlag sets the time flag
 	SetTimeFlag(bool)
+	// GroupingFlag returns true if the grouping flag is set.
 	GroupingFlag() bool
-	EBPTime() time.Time // time set in the EBP
+	// SetGroupingFlag sets the grouping flag.
+	SetGroupingFlag(bool)
+	// EBPTime returns the EBP time as a UTC time.
+	EBPTime() time.Time
+	// SetEBPTime sets the time of the EBP. Takes UTC time as an input.
 	SetEBPTime(time.Time)
-	EBPSuccessReadTime() time.Time // time the EBP was successfully read
+	// EBPSuccessReadTime defines when the EBP was read successfully.
+	EBPSuccessReadTime() time.Time
+	// SapFlag returns true if the sap flag is set.
 	SapFlag() bool
+	// SetSapFlag sets the sap flag.
 	SetSapFlag(bool)
+	// Sap returns the sap of the EBP.
 	Sap() byte
+	// SetSap sets the sap of the EBP.
 	SetSap(byte)
+	// ExtensionFlag returns true if the extension flag is set.
 	ExtensionFlag() bool
+	// SetExtensionFlag sets the extension flag.
 	SetExtensionFlag(bool)
+	// EBPtype returns the type (what is the format) of the EBP.
 	EBPType() byte
+	// IsEmpty returns if the EBP is empty (zero length)
+	IsEmpty() bool
+	// SetIsEmpty sets if the EBP is empty (zero length)
+	SetIsEmpty(bool)
+	// Data will return the raw bytes of the EBP
 	Data() []byte
 }

--- a/ebp/ebp.go
+++ b/ebp/ebp.go
@@ -56,7 +56,7 @@ func ReadEncoderBoundaryPoint(data io.Reader) (ebp EncoderBoundaryPoint, err err
 
 func extractUtcTime(seconds uint32, fraction uint32) time.Time {
 	nanos := uint64(seconds) * 1e9
-	nanos += (uint64(fraction) * 1e9) >> 32
+	nanos += (uint64(fraction) * 1e9) >> 32 // truncateing off 3 or 2 bits.
 
 	if seconds&0x80000000 != 0 { // if MSB set
 		// If bit 0 is set, the UTC time is in the range 1968-2036 and UTC
@@ -69,16 +69,18 @@ func extractUtcTime(seconds uint32, fraction uint32) time.Time {
 
 }
 
-func insertUtcTime(t time.Time, seconds *uint32, fraction *uint32) {
+func insertUtcTime(t time.Time) (seconds uint32, fraction uint32) {
 	var startingTime time.Time
 	if t.Before(time.Date(2036, 2, 7, 6, 28, 16, 0, time.UTC)) { // greater than or equal to
 		startingTime = time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC)
 	} else {
 		startingTime = time.Date(2036, 2, 7, 6, 28, 16, 0, time.UTC)
 	}
-	nanos := t.Sub(startingTime).Nanoseconds()
-	*seconds = uint32(nanos / 1e9)
-	nanos %= 1e9
-	nanos += 1
-	*fraction = uint32(nanos << 32 / 1e9)
+	nanos := uint64(t.Sub(startingTime).Nanoseconds())
+	seconds = uint32(nanos / 1e9)
+	// running extractUtcTime and then insertUtcTime will produce
+	// different results because of rounding that heppns twice.
+	// 1 is added to avoid truncating the second time.
+	fraction = uint32((((nanos % 1e9) + 1) << 32) / 1e9)
+	return
 }

--- a/ebp/ebp_test.go
+++ b/ebp/ebp_test.go
@@ -95,16 +95,15 @@ func TestExtractUtcTime(t *testing.T) {
 }
 
 func TestInsertUtcTime(t *testing.T) {
-	s := uint32(0xD6EE7BD8)
-	f := uint32(0x8DC714FC)
+	s0 := uint32(0xD6EE7BD8)
+	f0 := uint32(0x8DC714FC)
 	want := time.Unix(0, 1396964696553818999).UTC()
-	var s1, f1 uint32
-	insertUtcTime(want, &s1, &f1)
-	if s != s1 {
-		t.Errorf("secondsInserted=%d, secondsExpected=%d\n", s1, s)
+	s1, f1 := insertUtcTime(want)
+	if s0 != s1 {
+		t.Errorf("secondsInserted=%d, secondsExpected=%d\n", s1, s0)
 	}
-	if f != f1 {
-		t.Errorf("fractionInserted=%d, fractionExpected=%d\n", f1, f)
+	if f0 != f1 {
+		t.Errorf("fractionInserted=%d, fractionExpected=%d\n", f1, f0)
 	}
 
 }

--- a/ebp/ebp_test.go
+++ b/ebp/ebp_test.go
@@ -86,12 +86,27 @@ func TestReadEncoderBoundaryPoint(t *testing.T) {
 
 func TestExtractUtcTime(t *testing.T) {
 	s := uint32(0xD6EE7BD8)
-	f := uint32(0x8DC714FC)
+	f := uint32(0x8DC714FB)
 	got := extractUtcTime(s, f)
 	want := time.Unix(0, 1396964696553818999).UTC()
 	if want != got {
 		t.Errorf("TestUtcTime(), want=%v, got=%v, nanos=%d", want, got, got.UnixNano())
 	}
+}
+
+func TestInsertUtcTime(t *testing.T) {
+	s := uint32(0xD6EE7BD8)
+	f := uint32(0x8DC714FC)
+	want := time.Unix(0, 1396964696553818999).UTC()
+	var s1, f1 uint32
+	insertUtcTime(want, &s1, &f1)
+	if s != s1 {
+		t.Errorf("secondsInserted=%d, secondsExpected=%d\n", s1, s)
+	}
+	if f != f1 {
+		t.Errorf("fractionInserted=%d, fractionExpected=%d\n", f1, f)
+	}
+
 }
 
 // TODO TestUtcTimeAfter2036

--- a/ebp/ebp_test.go
+++ b/ebp/ebp_test.go
@@ -86,7 +86,7 @@ func TestReadEncoderBoundaryPoint(t *testing.T) {
 
 func TestExtractUtcTime(t *testing.T) {
 	s := uint32(0xD6EE7BD8)
-	f := uint32(0x8DC714FB)
+	f := uint32(0x8DC714FC)
 	got := extractUtcTime(s, f)
 	want := time.Unix(0, 1396964696553818999).UTC()
 	if want != got {


### PR DESCRIPTION
Added support for creating EBPs. Receiver types for EBPs changed to pointers in order to allow for modification. Data function added to convert EBPs back into raw bytes. Added GroupingFlag into EncoderBoundaryPoint interface since it is a common flag between Comcast and Cablelabs EBPs.

Example of new functionality:

	e := ebp.CreateCableLabsEbp()
	e.SetFragmentFlag(true)
	e.SetConcealmentFlag(true)
	e.SetExtensionFlag(true)
	e.SetPartitionFlag(true)
	e.SetSapFlag(true)
	e.SapType = 0x02
	e.SetGroupingFlag(true)
	e.Grouping = []byte{0xFF, 0x7F}
	e.SetTimeFlag(true)
	e.SetEBPTime(time.Unix(0, 1396964696553818999).UTC())
	e.PartitionFlags = 0x03
	e.ReservedBytes = []byte{0x04, 0x05}
	fmt.Printf("%X\n", e.Data())