### PR TITLE
packet: fix construction func return types

### DIFF
--- a/packet/adaptationfield.go
+++ b/packet/adaptationfield.go
@@ -31,7 +31,7 @@ import (
 // NewPacket creates a new packet with a Null ID, sync byte, and with the adaptation field control set to payload only.
 // This function is error free.
 func NewAdaptationField() *AdaptationField {
-	p := NewPacket()
+	p := New()
 	p.SetAdaptationFieldControl(AdaptationFieldFlag)
 	af, _ := p.AdaptationField()
 	return af

--- a/packet/adaptationfield_test.go
+++ b/packet/adaptationfield_test.go
@@ -38,7 +38,7 @@ func generatePacketAF(t *testing.T, AFString string) (*Packet, *AdaptationField)
 	if a == nil {
 		t.Errorf("adaptation field does not exist")
 	}
-	return &p, a
+	return p, a
 }
 
 func TestDiscontinuity(t *testing.T) {

--- a/packet/modify.go
+++ b/packet/modify.go
@@ -34,28 +34,28 @@ const (
 	invalidAdaptationFieldControlFlag     AdaptationFieldControlOptions     = 0 // 00
 )
 
-// NewPacket creates a new packet with a Null ID, sync byte, and with the adaptation field control set to payload only.
-// This function is error free.
-func NewPacket() (pkt Packet) {
+// New creates a new packet with a Null ID, sync byte, and with the adaptation
+// field control set to payload only.
+func New() *Packet {
 	//Default packet is the Null packet
-	pkt[0] = 0x47 // sets the sync byte
-	pkt[1] = 0x1F // equivalent to pkt.SetPID(NullPacketPid)
-	pkt[2] = 0xFF // equivalent to pkt.SetPID(NullPacketPid)
-	pkt[3] = 0x10 // equivalent to pkt.SetAdaptationFieldControl(PayloadFlag)
-	return
+	return &Packet{
+		0: 0x47,          // Sync byte
+		1: 0x1f, 2: 0xff, // pkt.SetPID(NullPacketPid)
+		3: 0x10, // pkt.SetAdaptationFieldControl(PayloadFlag)
+	}
 }
 
 // FromBytes creates a ts packet from a slice of bytes 188 in length.
 // If the bytes provided have errors or the slice is not 188 in length,
 // then an error vill be returned along with a nill slice.
-func FromBytes(bytes []byte) (pkt Packet, err error) {
+func FromBytes(bytes []byte) (*Packet, error) {
 	if len(bytes) != PacketSize {
-		err = gots.ErrInvalidPacketLength
-		return
+		return nil, gots.ErrInvalidPacketLength
 	}
+	var pkt Packet
 	copy(pkt[:], bytes)
-	err = pkt.CheckErrors()
-	return
+	err := pkt.CheckErrors()
+	return &pkt, err
 }
 
 // SetTransportErrorIndicator sets the Transport Error Indicator flag.

--- a/packet/modify_test.go
+++ b/packet/modify_test.go
@@ -52,7 +52,7 @@ const (
 		"77777777777777777777777777777777"
 )
 
-func createPacketEmptyPayload(t *testing.T, header string) (p Packet) {
+func createPacketEmptyPayload(t *testing.T, header string) *Packet {
 	headerBytes, _ := hex.DecodeString(header)
 	bodyBytes := make([]byte, 188-len(headerBytes))
 	packetBytes := append(headerBytes, bodyBytes...)
@@ -61,10 +61,10 @@ func createPacketEmptyPayload(t *testing.T, header string) (p Packet) {
 	if err != nil {
 		t.Error("packet error checking failed")
 	}
-	return
+	return p
 }
 
-func createPacketEmptyAdaptationField(t *testing.T, header string) (p Packet) {
+func createPacketEmptyAdaptationField(t *testing.T, header string) *Packet {
 	headerBytes, _ := hex.DecodeString(header)
 	AFBytes := make([]byte, 188)
 	AFBytes[4] = 183
@@ -79,7 +79,7 @@ func createPacketEmptyAdaptationField(t *testing.T, header string) (p Packet) {
 	if err != nil {
 		t.Error("packet error checking failed")
 	}
-	return
+	return p
 }
 
 func TestFromBytes(t *testing.T) {
@@ -102,27 +102,27 @@ func TestFromBytes(t *testing.T) {
 
 func TestNewPacket(t *testing.T) {
 	target := createPacketEmptyPayload(t, "471FFF10")
-	generated := NewPacket()
+	generated := New()
 	if err := generated.CheckErrors(); err != nil {
 		t.Error("Default packet has errors.")
 	}
-	if !Equal(&generated, &target) {
+	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nCreating a new packet failed.", generated, target)
 	}
 }
 
 func TestSetTransportErrorIndicator(t *testing.T) {
-	generated := NewPacket()
+	generated := New()
 
 	target := createPacketEmptyPayload(t, "479FFF10")
 	generated.SetTransportErrorIndicator(true)
-	if !Equal(&generated, &target) {
+	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the transport error indicator to true has failed.", generated, target)
 	}
 
 	target = createPacketEmptyPayload(t, "471FFF10")
 	generated.SetTransportErrorIndicator(false)
-	if !Equal(&generated, &target) {
+	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the transport error indicator to false has failed.", generated, target)
 	}
 }
@@ -136,17 +136,17 @@ func TestTransportErrorIndicator(t *testing.T) {
 }
 
 func TestSetPayloadUnitStartIndicator(t *testing.T) {
-	generated := NewPacket()
+	generated := New()
 
 	target := createPacketEmptyPayload(t, "475FFF10")
 	generated.SetPayloadUnitStartIndicator(true)
-	if !Equal(&generated, &target) {
+	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the PUSI to true has failed.", generated, target)
 	}
 
 	target = createPacketEmptyPayload(t, "471FFF10")
 	generated.SetPayloadUnitStartIndicator(false)
-	if !Equal(&generated, &target) {
+	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the PUSI to false has failed.", generated, target)
 	}
 }
@@ -160,17 +160,17 @@ func TestPayloadUnitStartIndicator(t *testing.T) {
 }
 
 func TestSetTP(t *testing.T) {
-	generated := NewPacket()
+	generated := New()
 
 	target := createPacketEmptyPayload(t, "473FFF10")
 	generated.SetTransportPriority(true)
-	if !Equal(&generated, &target) {
+	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the transport priority to true has failed.", generated, target)
 	}
 
 	target = createPacketEmptyPayload(t, "471FFF10")
 	generated.SetTransportPriority(false)
-	if !Equal(&generated, &target) {
+	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the transport priority to false has failed.", generated, target)
 	}
 }
@@ -188,21 +188,21 @@ func TestSetPID(t *testing.T) {
 
 	target := createPacketEmptyPayload(t, "47f76A10")
 	generated.SetPID(0x176A)
-	if !Equal(&generated, &target) {
+	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the PID to 0x176A has failed.", generated, target)
 	}
 
-	generated = NewPacket()
+	generated = New()
 
 	target = createPacketEmptyPayload(t, "47000010")
 	generated.SetPID(0x0000)
-	if !Equal(&generated, &target) {
+	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the PID to 0x0000 has failed.", generated, target)
 	}
 
 	target = createPacketEmptyPayload(t, "471fec10")
 	generated.SetPID(0x1fec)
-	if !Equal(&generated, &target) {
+	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the PID to 0x1fec has failed.", generated, target)
 	}
 }
@@ -216,23 +216,23 @@ func TestPID(t *testing.T) {
 }
 
 func TestSetTransportScramblingControl(t *testing.T) {
-	generated := NewPacket()
+	generated := New()
 
 	target := createPacketEmptyPayload(t, "471FFFD0")
 	generated.SetTransportScramblingControl(ScrambleOddKeyFlag)
-	if !Equal(&generated, &target) {
+	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Transport Scrambling Control to ScrambleOddKeyFlag has failed.", generated, target)
 	}
 
 	target = createPacketEmptyPayload(t, "471FFF90")
 	generated.SetTransportScramblingControl(ScrambleEvenKeyFlag)
-	if !Equal(&generated, &target) {
+	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Transport Scrambling Control to ScrambleEvenKeyFlag has failed.", generated, target)
 	}
 
 	target = createPacketEmptyPayload(t, "471FFF10")
 	generated.SetTransportScramblingControl(NoScrambleFlag)
-	if !Equal(&generated, &target) {
+	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Transport Scrambling Control to NoScrambleFlag has failed.", generated, target)
 	}
 }
@@ -258,24 +258,24 @@ func TestTransportScramblingControl(t *testing.T) {
 }
 
 func TestSetAdaptationFieldControl(t *testing.T) {
-	generated := NewPacket()
+	generated := New()
 
 	target := createPacketEmptyPayload(t, "471FFF10")
 	generated.SetAdaptationFieldControl(PayloadFlag)
-	if !Equal(&generated, &target) {
+	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Adaptation Field Control to PayloadFlag has failed.", generated, target)
 	}
 
 	target = createPacketEmptyAdaptationField(t, "471FFF30B6")
 	generated.SetAdaptationFieldControl(PayloadAndAdaptationFieldFlag)
-	if !Equal(&generated, &target) {
+	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Adaptation Field Control to PayloadAndAdaptationFieldFlag has failed.", generated, target)
 	}
 
 	target = createPacketEmptyAdaptationField(t, "471FFF20")
 	generated.SetAdaptationFieldControl(PayloadFlag)
 	generated.SetAdaptationFieldControl(AdaptationFieldFlag)
-	if !Equal(&generated, &target) {
+	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Adaptation Field Control to AdaptationFieldFlag has failed.", generated, target)
 	}
 }
@@ -300,11 +300,11 @@ func TestAdaptationFieldControl(t *testing.T) {
 
 func TestSetContinuityCounter(t *testing.T) {
 	target := createPacketEmptyPayload(t, "471FFF1f")
-	generated := NewPacket()
+	generated := New()
 
 	generated.SetContinuityCounter(15)
 
-	if !Equal(&generated, &target) {
+	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the Continuity Counter to 15 has failed.", generated, target)
 	}
 }
@@ -319,13 +319,13 @@ func TestContinuityCounterModify(t *testing.T) {
 
 func TestIncContinuityCounter(t *testing.T) {
 	target := createPacketEmptyPayload(t, "471FFF10")
-	generated := NewPacket()
+	generated := New()
 
 	generated.SetContinuityCounter(0xFE) // cc = 14
 	generated.IncContinuityCounter()     // cc = 15
 	generated.IncContinuityCounter()     // cc = 0, overflow
 
-	if !Equal(&generated, &target) {
+	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nContinuity Counter did not rollover as expected.", generated, target)
 	}
 }
@@ -384,7 +384,7 @@ func TestHasPayload(t *testing.T) {
 
 func TestHeaderBasic(t *testing.T) {
 	target := createPacketEmptyPayload(t, "47EFA098")
-	generated := NewPacket()
+	generated := New()
 
 	generated.SetContinuityCounter(7)
 	generated.IncContinuityCounter()
@@ -395,7 +395,7 @@ func TestHeaderBasic(t *testing.T) {
 	generated.SetAdaptationFieldControl(PayloadFlag)
 	generated.SetTransportScramblingControl(ScrambleEvenKeyFlag)
 
-	if !Equal(&generated, &target) {
+	if !Equal(generated, target) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nFields did not set successfully", generated, target)
 	}
 
@@ -445,7 +445,7 @@ func TestSetPayload(t *testing.T) {
 		t.Error(err.Error())
 		return
 	}
-	p := NewPacket()
+	p := New()
 	err = p.SetAdaptationFieldControl(AdaptationFieldFlag)
 	if err != nil {
 		t.Error(err.Error())
@@ -482,7 +482,7 @@ func TestSetPayload(t *testing.T) {
 		t.Error(err.Error())
 		return
 	}
-	if !Equal(&target, &p) {
+	if !Equal(target, p) {
 		t.Errorf("crafted packet:\n%X \ndoes not match expected packet:\n%X\nSetting the payload failed.", p, target)
 	}
 	payloadInPacket, _ := p.Payload()
@@ -494,7 +494,7 @@ func TestSetPayload(t *testing.T) {
 func BenchmarkNewStyleAllFields(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		// create everything
-		p := NewPacket()
+		p := New()
 		p.SetContinuityCounter(7)
 		p.IncContinuityCounter()
 		p.SetPID(4000)
@@ -542,7 +542,7 @@ func BenchmarkNewStyleAllFields(b *testing.B) {
 
 func BenchmarkNewStyleCreate(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		pkt := NewPacket()
+		pkt := New()
 		pkt.SetPID(13)
 		pkt.SetAdaptationFieldControl(PayloadFlag)
 		pkt.SetPayloadUnitStartIndicator(true)
@@ -562,7 +562,7 @@ func BenchmarkOldStyleCreate(b *testing.B) {
 }
 
 func BenchmarkNewStyleRead(b *testing.B) {
-	pkt := NewPacket()
+	pkt := New()
 	pkt.SetPID(13)
 	pkt.SetAdaptationFieldControl(PayloadFlag)
 	pkt.SetPayloadUnitStartIndicator(true)
@@ -578,7 +578,7 @@ func BenchmarkNewStyleRead(b *testing.B) {
 }
 
 func BenchmarkOldStyleRead(b *testing.B) {
-	pkt := NewPacket()
+	pkt := New()
 	pkt.SetPID(13)
 	pkt.SetAdaptationFieldControl(PayloadFlag)
 	pkt.SetPayloadUnitStartIndicator(true)
@@ -586,9 +586,9 @@ func BenchmarkOldStyleRead(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		ContinuityCounter(&pkt)
-		PayloadUnitStartIndicator(&pkt)
-		ContainsPayload(&pkt)
-		Pid(&pkt)
+		ContinuityCounter(pkt)
+		PayloadUnitStartIndicator(pkt)
+		ContainsPayload(pkt)
+		Pid(pkt)
 	}
 }


### PR DESCRIPTION
The Packet type's methods are all on the pointer, so the constructors should return a pointer. I missed this in the review of #92.

Also changes `packet.NewPacket` to `packet.New` to avoid stutter (also missed in review of #92).

Please take a look.