### PR TITLE
Gots coral bugfix

### DIFF
--- a/packet/create.go
+++ b/packet/create.go
@@ -163,7 +163,7 @@ func WithPUSI(pkt *Packet) {
 
 // WithContinuousAF is an option function for creating a packet with a continuous adaptation field
 func WithContinuousAF(pkt *Packet) {
-	pkt[5] |= 0x7fgi
+	pkt[5] |= 0x7f
 }
 
 // WithDisconinuousAF is an option function for creating a packet with a discontinuous adaptation field

--- a/packet/create.go
+++ b/packet/create.go
@@ -148,7 +148,7 @@ func WithHasPayloadFlag(pkt *Packet) {
 
 // WithHasAdaptationFieldFlag is an option function for creating a packet with an adaptation field
 func WithHasAdaptationFieldFlag(pkt *Packet) {
-	pkt[3] |= 0x02
+	pkt[3] |= 0x20
 }
 
 // WithAFPrivateDataFlag is an option function for creating a packet with a adaptation field private data flag
@@ -163,7 +163,7 @@ func WithPUSI(pkt *Packet) {
 
 // WithContinuousAF is an option function for creating a packet with a continuous adaptation field
 func WithContinuousAF(pkt *Packet) {
-	pkt[5] |= 0x7f
+	pkt[5] |= 0x7fgi
 }
 
 // WithDisconinuousAF is an option function for creating a packet with a discontinuous adaptation field

--- a/psi/pmt.go
+++ b/psi/pmt.go
@@ -228,7 +228,7 @@ func FilterPMTPacketsToPids(packets []*packet.Packet, pids []uint16) []*packet.P
 		filteredPMT.Write(pmtPayload[programInfoLengthOffset+2 : programInfoLengthOffset+2+programInfoLength])
 	}
 
-	for offset := programInfoLengthOffset + 2 + programInfoLength; offset < sectionLength-pmtEsDescriptorStaticLen-CrcLen; {
+	for offset := programInfoLengthOffset + 2 + programInfoLength; offset < PSIHeaderLen+sectionLength-pmtEsDescriptorStaticLen-CrcLen; {
 		elementaryPid := uint16(pmtPayload[offset+1]&0x1f)<<8 | uint16(pmtPayload[offset+2])
 		infoLength := uint16(pmtPayload[offset+3]&0x0f)<<8 | uint16(pmtPayload[offset+4])
 


### PR DESCRIPTION
This PR fixes a bug where the hasAdaptationField flag was being set with the wrong bits. The bits were being ORed with 0x02 when they should be ORed with 0x20. This was causing CC validation to fail and thus causing Coral to fail tests. This PR also includes a previous change to include PSIHeaderLength when moving the offset to filter PIDS from the PMT in order to avoid dropping the SCTE pid causing Coral to fail another test.