### PR TITLE
added back the conditional that checks whether a newly accumulated…

### DIFF
--- a/packet/accumulator.go
+++ b/packet/accumulator.go
@@ -56,6 +56,11 @@ func (a *accumulator) Add(pkt []byte) (bool, error) {
 	if !p || err != nil {
 		return false, err
 	}
+	// need to check if the packet contains a payloadUnitStartIndicator so we know
+	// to drop old packets and re-accumulate a new scte signal
+	if payloadUnitStartIndicator(&pp) {
+		a.packets = make([]*Packet, 0)
+	}
 	if !payloadUnitStartIndicator(&pp) && len(a.packets) == 0 {
 		// First packet must have payload unit start indicator
 		return false, gots.ErrNoPayloadUnitStartIndicator

--- a/packet/accumulator.go
+++ b/packet/accumulator.go
@@ -59,7 +59,7 @@ func (a *accumulator) Add(pkt []byte) (bool, error) {
 	// need to check if the packet contains a payloadUnitStartIndicator so we know
 	// to drop old packets and re-accumulate a new scte signal
 	if payloadUnitStartIndicator(&pp) {
-		a.packets = make([]*Packet, 0)
+		a.Reset()
 	}
 	if !payloadUnitStartIndicator(&pp) && len(a.packets) == 0 {
 		// First packet must have payload unit start indicator


### PR DESCRIPTION
… SCTE packet contains a payload start indicator

This conditional check was removed in a previous PR. However, without this check packets are continually added to the accumulation. When parsing the signal descriptors for SCTE packets, the first packet's payload is parsed, causing duplicate descriptors to occur. This change resets the accumulated packets whenever a new payload start indicator is encountered.