### PR TITLE
Removing unncecessary multi-value returns when the returned err is always nil.

### DIFF
--- a/cli/parsefile.go
+++ b/cli/parsefile.go
@@ -116,11 +116,7 @@ func main() {
 		}
 		numPackets++
 		if *dumpSCTE35 {
-			currPID, err := packet.Pid(&pkt)
-			if err != nil {
-				fmt.Printf("Cannot get packet PID for %d\n", currPID)
-				continue
-			}
+			currPID := packet.Pid(&pkt)
 			if scte35PIDs[currPID] {
 				pay, err := packet.Payload(&pkt)
 				if err != nil {
@@ -154,10 +150,7 @@ func main() {
 		}
 		if *showPacketNumberOfPID != 0 {
 			pid := uint16(*showPacketNumberOfPID)
-			pktPid, err := packet.Pid(&pkt)
-			if err != nil {
-				continue
-			}
+			pktPid := packet.Pid(&pkt)
 			if pktPid == pid {
 				fmt.Printf("First Packet of PID %d contents: %x\n", pid, pkt)
 				break

--- a/packet/accumulator.go
+++ b/packet/accumulator.go
@@ -52,16 +52,16 @@ func (a *accumulator) Add(pkt []byte) (bool, error) {
 	copy(pp[:], pkt)
 	// technically we could get a packet without a payload.  Check this and
 	// return false if we get one
-	p, err := ContainsPayload(&pp)
-	if !p || err != nil {
-		return false, err
+	p := ContainsPayload(&pp)
+	if !p {
+		return false, nil
 	}
 	// need to check if the packet contains a payloadUnitStartIndicator so we know
 	// to drop old packets and re-accumulate a new scte signal
-	if payloadUnitStartIndicator(&pp) {
+	if PayloadUnitStartIndicator(&pp) {
 		a.Reset()
 	}
-	if !payloadUnitStartIndicator(&pp) && len(a.packets) == 0 {
+	if !PayloadUnitStartIndicator(&pp) && len(a.packets) == 0 {
 		// First packet must have payload unit start indicator
 		return false, gots.ErrNoPayloadUnitStartIndicator
 	}

--- a/packet/adaptationfield/adaptationfield.go
+++ b/packet/adaptationfield/adaptationfield.go
@@ -55,10 +55,7 @@ func HasAdaptationFieldExtension(pkt *packet.Packet) bool {
 // EncoderBoundaryPoint returns the byte array located in the optional TransportPrivateData of the (also optional)
 // AdaptationField of the Packet. If either of these optional fields are missing an empty byte array is returned with an error
 func EncoderBoundaryPoint(pkt *packet.Packet) ([]byte, error) {
-	hasAdapt, err := packet.ContainsAdaptationField(pkt)
-	if err != nil {
-		return nil, nil
-	}
+	hasAdapt := packet.ContainsAdaptationField(pkt)
 	if hasAdapt && Length(pkt) > 0 && HasTransportPrivateData(pkt) {
 		ebp, err := TransportPrivateData(pkt)
 		if err != nil {

--- a/packet/create.go
+++ b/packet/create.go
@@ -96,34 +96,34 @@ func Create(pid uint16, options ...func(*Packet)) *Packet {
 func CreateTestPacket(pid uint16, cc uint8, pusi, hasPay bool) *Packet {
 	var pkt *Packet
 	if hasPay && pusi {
-		pkt, _ = SetCC(
+		pkt = SetCC(
 			Create(pid,
 				WithHasPayloadFlag,
 				WithContinuousAF,
 				WithPUSI),
 			cc)
 	} else if hasPay {
-		pkt, _ = SetCC(
+		pkt = SetCC(
 			Create(pid,
 				WithHasPayloadFlag,
 				WithContinuousAF),
 			cc)
 
 	} else {
-		pkt, _ = SetCC(Create(pid, WithContinuousAF), cc)
+		pkt = SetCC(Create(pid, WithContinuousAF), cc)
 	}
 	return pkt
 }
 
 // CreateDCPacket creates a new packet with a discontinuous adapataion field and the given PID and CC
 func CreateDCPacket(pid uint16, cc uint8) *Packet {
-	pkt, _ := SetCC(Create(pid, WithDiscontinuousAF, WithHasPayloadFlag), cc)
+	pkt := SetCC(Create(pid, WithDiscontinuousAF, WithHasPayloadFlag), cc)
 	return pkt
 }
 
 // CreatePacketWithPayload creates a new packet with the given PID, CC and payload
 func CreatePacketWithPayload(pid uint16, cc uint8, pay []byte) *Packet {
-	pkt, _ := SetCC(
+	pkt := SetCC(
 		Create(
 			pid,
 			WithHasPayloadFlag,
@@ -136,6 +136,7 @@ func CreatePacketWithPayload(pid uint16, cc uint8, pay []byte) *Packet {
 	)
 	return pkt
 }
+
 func setPid(pkt *Packet, pid uint16) {
 	pkt[1] = byte(pid >> 8 & 0x1f)
 	pkt[2] = byte(pid & 0xff)

--- a/packet/packet_test.go
+++ b/packet/packet_test.go
@@ -53,10 +53,11 @@ func TestPayloadUnitStartIndicatorTrue(t *testing.T) {
 			"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
 			"ffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 	expected := true
-	if pusi, err := PayloadUnitStartIndicator(packet); pusi != expected || err != nil {
-		t.Errorf("PayloadUnitStartIndicator() = %t, want %t err = %v", pusi, expected, err)
+	if pusi := PayloadUnitStartIndicator(packet); pusi != expected {
+		t.Errorf("PayloadUnitStartIndicator() = %t, want %t", pusi, expected)
 	}
 }
+
 func TestPayloadUnitStartIndicatorFalse(t *testing.T) {
 	packet := parseHexString(
 		"4700673b7000ffffffffffffffffffffffffffffffffffffffffffffffffffff" +
@@ -66,8 +67,8 @@ func TestPayloadUnitStartIndicatorFalse(t *testing.T) {
 			"cb2e84e04544cd54b9ffb497e788f2b308d1a71d4f2bce4c18c563b92ecd954b" +
 			"558e7ca55796ca56ed4020812c21f1013ff5497f875897f58ffeeb1c")
 	expected := false
-	if pusi, err := PayloadUnitStartIndicator(packet); pusi != expected || err != nil {
-		t.Errorf("PayloadUnitStartIndicator() = %t, want %t err = %v", pusi, expected, err)
+	if pusi := PayloadUnitStartIndicator(packet); pusi != expected {
+		t.Errorf("PayloadUnitStartIndicator() = %t, want %t", pusi, expected)
 	}
 }
 
@@ -80,8 +81,8 @@ func TestPid(t *testing.T) {
 			"0ba9b7a659363d7347d22f835b4e53f6472f01be53d7df28ea7f1764972f5549" +
 			"34096bd6bf42eabe1dff1c59e0cc55a716b6a40618b3305b45779c31")
 	expected := uint16(102)
-	if pid, err := Pid(packet); pid != expected || err != nil {
-		t.Errorf("Pid() = %d, want %d err=%v", pid, expected, err)
+	if pid := Pid(packet); pid != expected {
+		t.Errorf("Pid() = %d, want %d", pid, expected)
 	}
 }
 
@@ -94,8 +95,8 @@ func TestPidGreaterThan255(t *testing.T) {
 			"0ba9b7a659363d7347d22f835b4e53f6472f01be53d7df28ea7f1764972f5549" +
 			"34096bd6bf42eabe1dff1c59e0cc55a716b6a40618b3305b45779c31")
 	expected := uint16(290)
-	if pid, err := Pid(packet); pid != expected || err != nil {
-		t.Errorf("Pid() = %d, want %d err=%v", pid, expected, err)
+	if pid := Pid(packet); pid != expected {
+		t.Errorf("Pid() = %d, want %d", pid, expected)
 	}
 }
 
@@ -108,8 +109,8 @@ func TestContainsPayloadTrue(t *testing.T) {
 			"0ba9b7a659363d7347d22f835b4e53f6472f01be53d7df28ea7f1764972f5549" +
 			"34096bd6bf42eabe1dff1c59e0cc55a716b6a40618b3305b45779c31")
 	expected := true
-	if containsPayload, err := ContainsPayload(packet); containsPayload != expected || err != nil {
-		t.Errorf("ContainsPayload() = %t, want %t err=%v", containsPayload, expected, err)
+	if containsPayload := ContainsPayload(packet); containsPayload != expected {
+		t.Errorf("ContainsPayload() = %t, want %tv", containsPayload, expected)
 	}
 }
 
@@ -122,7 +123,7 @@ func TestContainsPayloadFalse(t *testing.T) {
 			"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
 			"ffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 	expected := false
-	if containsPayload, err := ContainsPayload(packet); containsPayload != expected || err != nil {
+	if containsPayload := ContainsPayload(packet); containsPayload != expected {
 		t.Errorf("ContainsPayload() = %t, want %t", containsPayload, expected)
 	}
 }
@@ -136,7 +137,7 @@ func TestContinuityCounter(t *testing.T) {
 			"43e5d197998e05e2a50f590f6923d45490c81750d5f603643f974a2bde5f4812" +
 			"749dd96f61281aca2cb496c01f01e3152fcba48c2ec78314ab21da3b")
 	expected := uint8(8)
-	if cc, err := ContinuityCounter(packet); cc != expected || err != nil {
+	if cc := ContinuityCounter(packet); cc != expected {
 		t.Errorf("ContinuityCounter() = %d, want %d", cc, expected)
 	}
 }
@@ -151,9 +152,8 @@ func TestZeroLenthAdaptationField(t *testing.T) {
 			"9ab1852b9314ae15fad86177607b75be718f0c07d22400845160d980")
 
 	expected := true
-
-	if hasadapt, err := ContainsAdaptationField(packet); hasadapt != expected || err != nil {
-		t.Errorf("ContainsAdaptationField() = %v, want %v (%v)", hasadapt, expected, err)
+	if hasadapt := ContainsAdaptationField(packet); hasadapt != expected {
+		t.Errorf("ContainsAdaptationField() = %v, want %v", hasadapt, expected)
 	}
 }
 
@@ -209,15 +209,12 @@ func TestIncrementCC(t *testing.T) {
 			"cb2e84e04544cd54b9ffb497e788f2b308d1a71d4f2bce4c18c563b92ecd954b" +
 			"558e7ca55796ca56ed4020812c21f1013ff5497f875897f58ffeeb1c")
 	packet[3] = byte(0x00)
-	newPacket, err := IncrementCC(packet)
-	if err != nil {
-		t.Error(err)
-	}
+	newPacket := IncrementCC(packet)
+
 	expected := uint8(1)
 	if expected != newPacket[3] {
 		t.Errorf("CC= %x, want %x", newPacket[3], expected)
 	}
-
 }
 
 func TestBadLength(t *testing.T) {
@@ -255,7 +252,7 @@ func TestContainsAdaptationField(t *testing.T) {
 			"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffa0b82aaa" +
 			"bd5a13a6b27a23c4e556bd78ccdb05c72a3a5cac278d76d89aae3de5241728ea" +
 			"ea79344f6ff95e63bd6060c9462c42b33a89b3fcff000480003e71c0")
-	if exists, _ := ContainsAdaptationField(packet); !exists {
+	if exists := ContainsAdaptationField(packet); !exists {
 		t.Error("Did not correctly find presence of adaptation field")
 	}
 }
@@ -319,9 +316,9 @@ func TestNullPacketIsNull(t *testing.T) {
 			"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
 			"ffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 
-	if isNull, _ := IsNull(p); isNull == false {
-		pid, e := Pid(p)
-		t.Errorf("Packets with PID == %d should be null. PID was %v and error was %v", NullPacketPid, pid, e)
+	if isNull := IsNull(p); isNull == false {
+		pid := Pid(p)
+		t.Errorf("Packets with PID == %d should be null. PID was %v", NullPacketPid, pid)
 	}
 }
 
@@ -334,7 +331,7 @@ func TestNonNullPacketIsNotNull(t *testing.T) {
 			"2980fc8080ff800000000125b80100017fb2c69de69e51f57c4a1b8623115f78" +
 			"053598e7f47c066bf03c90c6233c0405369fd5f8e20957e40437f784")
 
-	if isNull, _ := IsNull(packet1); isNull == true {
+	if isNull := IsNull(packet1); isNull == true {
 		t.Errorf("Packets with PID != %d should not be null.", NullPacketPid)
 	}
 }
@@ -348,7 +345,7 @@ func TestIsPat(t *testing.T) {
 			"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
 			"ffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 
-	if isPat, _ := IsPat(pat); isPat == false {
+	if isPat := IsPat(pat); isPat == false {
 		t.Error("PAT packet should be counted as a PAT")
 	}
 
@@ -360,7 +357,7 @@ func TestIsPat(t *testing.T) {
 			"2980fc8080ff800000000125b80100017fb2c69de69e51f57c4a1b8623115f78" +
 			"053598e7f47c066bf03c90c6233c0405369fd5f8e20957e40437f784")
 
-	if isPat2, _ := IsPat(notPat); isPat2 == true {
+	if isPat2 := IsPat(notPat); isPat2 == true {
 		t.Error("Non PAT Packet shouldn't be counted as a PAT")
 	}
 }

--- a/psi/pat.go
+++ b/psi/pat.go
@@ -123,10 +123,8 @@ func ReadPAT(r io.Reader) (PAT, error) {
 			}
 			return nil, err
 		}
-		isPat, err := packet.IsPat(&pkt)
-		if err != nil {
-			return nil, err
-		}
+		isPat := packet.IsPat(&pkt)
+
 		if isPat {
 			pay, err := packet.Payload(&pkt)
 			if err != nil {

--- a/psi/pmt.go
+++ b/psi/pmt.go
@@ -258,10 +258,7 @@ func FilterPMTPacketsToPids(packets []*packet.Packet, pids []uint16) []*packet.P
 	var filteredPMTPackets []*packet.Packet
 	for _, pkt := range packets {
 		var pktBuf bytes.Buffer
-		header, err := packet.Header(pkt)
-		if err != nil {
-			break
-		}
+		header := packet.Header(pkt)
 		pktBuf.Write(header)
 		if len(fPMT) > 0 {
 			toWrite := safeSlice(fPMT, 0, packet.PacketSize-len(header))
@@ -291,11 +288,7 @@ func IsPMT(pkt *packet.Packet, pat PAT) (bool, error) {
 	}
 
 	pmtMap := pat.ProgramMap()
-	pid, err := packet.Pid(pkt)
-
-	if err != nil {
-		return false, err
-	}
+	pid := packet.Pid(pkt)
 
 	for _, map_pid := range pmtMap {
 		if pid == map_pid {
@@ -337,9 +330,12 @@ func pidIn(pids []uint16, target uint16) bool {
 // otherwise returns an error.
 func ReadPMT(r io.Reader, pid uint16) (PMT, error) {
 	var pkt packet.Packet
+	var err error
+	var pmt PMT
+
 	pmtAcc := packet.NewAccumulator(PmtAccumulatorDoneFunc)
 	done := false
-	var pmt PMT
+
 	for !done {
 		if _, err := io.ReadFull(r, pkt[:]); err != nil {
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
@@ -347,10 +343,7 @@ func ReadPMT(r io.Reader, pid uint16) (PMT, error) {
 			}
 			return nil, err
 		}
-		currPid, err := packet.Pid(&pkt)
-		if err != nil {
-			return nil, err
-		}
+		currPid := packet.Pid(&pkt)
 		if currPid != pid {
 			continue
 		}

--- a/psi/pmt_test.go
+++ b/psi/pmt_test.go
@@ -658,6 +658,7 @@ func TestIsPMTErrorConditions(t *testing.T) {
 		t.Error("Couldn't load the PAT")
 	}
 }
+
 func TestReadPMTForSmoke(t *testing.T) {
 	bs, _ := hex.DecodeString("474000100000b00d0001c100000001e256f803e71bfffffff" +
 		"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
@@ -676,14 +677,14 @@ func TestReadPMTForSmoke(t *testing.T) {
 	pid := uint16(598)
 	pmt, err := ReadPMT(r, pid)
 	if err != nil {
-		t.Errorf("Unexpected error reading PMT: %v", err)
-		return
+		t.Fatalf("Unexpected error reading PMT: %v", err)
 	}
 	// sanity check (tests integration a bit)
 	if len(pmt.ElementaryStreams()) != 2 {
 		t.Errorf("PMT read is invalid, did not have expected number of streams")
 	}
 }
+
 func TestReadPMTIncomplete(t *testing.T) {
 	bs, _ := hex.DecodeString("474000100000b00d0001c100000001e256f803e71bfffffff" +
 		"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
@@ -897,5 +898,4 @@ func TestIsDolbyATMOS(t *testing.T) {
 	if !hasATMOS {
 		t.Errorf("Positive Dolby ATMOS Stream failed. Supposed to be a Dolby ATMOS stream.")
 	}
-
 }


### PR DESCRIPTION
These were leftover from PR #84.