### PR TITLE
Patch 2

### DIFF
--- a/psi/pat.go
+++ b/psi/pat.go
@@ -89,8 +89,6 @@ func (pat pat) ProgramMap() map[uint16]uint16 {
 
 		// ignore the top three (reserved) bits
 		pid := uint16(pat[counter+3])&0x1f<<8 | uint16(pat[counter+4])
-
-		m[pn] = pid
 		
 		// A value of 0 is reserved for a NIT packet identifier.
 		if pn > 0 {

--- a/psi/pat.go
+++ b/psi/pat.go
@@ -91,7 +91,12 @@ func (pat pat) ProgramMap() map[uint16]uint16 {
 		pid := uint16(pat[counter+3])&0x1f<<8 | uint16(pat[counter+4])
 
 		m[pn] = pid
-
+		
+		// A value of 0 is reserved for a NIT packet identifier.
+		if pn > 0 {
+			m[pn] = pid
+		}
+		
 		counter += 4
 	}
 


### PR DESCRIPTION
Program num	value of 0 is reserved for a NIT packet identifier. We should ignore the element with pn==0 in PAT