### PR TITLE
gots.InsertPTS improvements

### DIFF
--- a/pts.go
+++ b/pts.go
@@ -129,7 +129,7 @@ func InsertPTS(b []byte, pts uint64) {
 	b[4] = byte(pts&0xff) << 1    // PTS[7..0]
 
 	// Set the marker bits as appropriate
-	b[0] |= 0x21
+	b[0] |= 0x01
 	b[2] |= 0x01
 	b[4] |= 0x01
 }

--- a/pts_test.go
+++ b/pts_test.go
@@ -35,7 +35,7 @@ func TestPTSIsAfterWithoutRollover(t *testing.T) {
 
 func TestPTSIsAfterWithRollover(t *testing.T) {
 	p := PTS(1)
-	other := PTS(8589934591) // MaxPtsValue
+	other := PTS(MaxPtsValue)
 	if !p.After(other) {
 		t.Errorf("PTS=%v, not After other=%v", p, other)
 	}
@@ -125,8 +125,15 @@ func TestAdd(t *testing.T) {
 func TestInsertPTS(t *testing.T) {
 	var pts uint64 = 0x1DEADBEEF
 	b := make([]byte, 5)
+
 	InsertPTS(b, pts)
-	if ExtractTime(b) != 0x1DEADBEEF {
-		t.Error("Insert PTS test 1 failed")
+	if ots := ExtractTime(b); ots != pts {
+		t.Errorf("Insert PTS test 1 failed: %v != %v", ots, pts)
+	}
+
+	pts = MaxPtsValue
+	InsertPTS(b, pts)
+	if ots := ExtractTime(b); ots != pts {
+		t.Errorf("Insert PTS test 2 failed: %v != %v", ots, pts)
 	}
 }


### PR DESCRIPTION
cleaned up the tests a bit, and fixed what appears to be a bug in the marker bit insertion.