### PR TITLE
Remove reader in favor of indexing

### DIFF
--- a/cli/parsefile.go
+++ b/cli/parsefile.go
@@ -27,7 +27,6 @@ package main
 
 import (
 	"bufio"
-	"bytes"
 	"flag"
 	"fmt"
 	"io"
@@ -139,8 +138,7 @@ func main() {
 				// Not an EBP
 				continue
 			}
-			buf := bytes.NewBuffer(ebpBytes)
-			boundaryPoint, err := ebp.ReadEncoderBoundaryPoint(buf)
+			boundaryPoint, err := ebp.ReadEncoderBoundaryPoint(ebpBytes)
 			if err != nil {
 				fmt.Printf("EBP construction error %v", err)
 				continue

--- a/ebp/cablelabsebp_test.go
+++ b/ebp/cablelabsebp_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestParseCableLabsEBP(t *testing.T) {
-	ebp, err := readCableLabsEbp(bytes.NewBuffer(CableLabsEBPBytes[1:]))
+	ebp, err := readCableLabsEbp(CableLabsEBPBytes)
 	if err != nil {
 		t.Errorf("readCableLabsEbp() returned not null error on valid EBP %v", err)
 	}
@@ -74,7 +74,7 @@ func TestParseCableLabsEBP(t *testing.T) {
 		t.Errorf("readCableLabsEbp() has incorrect reserved, %v", ebp.ReservedBytes)
 	}
 
-	ebp, err = readCableLabsEbp(bytes.NewBuffer([]byte{0xff, 0xf3}))
+	ebp, err = readCableLabsEbp([]byte{0xff, 0xf3})
 	if err == nil {
 		t.Errorf("readCableLabsEbp() returned null error %v on invalid EBP", err)
 	}

--- a/ebp/comcastebp.go
+++ b/ebp/comcastebp.go
@@ -27,8 +27,9 @@ package ebp
 import (
 	"bytes"
 	"encoding/binary"
-	"io"
 	"time"
+
+	"github.com/Comcast/gots"
 )
 
 // cableLabsEbp is an encoder boundary point
@@ -65,64 +66,62 @@ func (ebp *comcastEbp) SetDiscontinuityFlag(value bool) {
 }
 
 // readComcastEbp will parse raw bytes without the tag into a Comcast EBP.
-func readComcastEbp(data io.Reader) (ebp *comcastEbp, err error) {
+func readComcastEbp(data []byte) (ebp *comcastEbp, err error) {
 	ebp = &comcastEbp{
 		baseEbp: baseEbp{DataFieldTag: ComcastEbpTag},
 	}
 
-	if err = binary.Read(data, ebpEncoding, &ebp.DataFieldLength); err != nil {
-		return nil, err
+	// We read 2 bytes not based on flags
+	if len(data) < 2 {
+		return nil, gots.ErrNoPayload
 	}
 
-	remaining := ebp.DataFieldLength
+	index := uint8(0)
 
-	if remaining == 0 {
-		return ebp, nil
+	ebp.DataFieldTag = data[index]
+	index += uint8(1)
+
+	ebp.DataFieldLength = data[index]
+	index += uint8(1)
+
+	// Check if the data is as advertised
+	if ebp.DataFieldLength > 0 {
+		if len(data) >= 3 {
+			ebp.DataFlags = data[index]
+			index += uint8(1)
+		} else {
+			return nil, gots.ErrInvalidEBPLength
+		}
 	}
-
-	if err = binary.Read(data, ebpEncoding, &ebp.DataFlags); err != nil {
-		return nil, err
-	}
-
-	remaining -= uint8(1)
 
 	if ebp.ExtensionFlag() {
-		if err = binary.Read(data, ebpEncoding, &ebp.ExtensionFlags); err != nil {
-			return nil, err
-		}
-		remaining -= uint8(1)
+		ebp.ExtensionFlags = data[index]
+		index += uint8(1)
 	}
 
 	if ebp.SapFlag() {
-		if err = binary.Read(data, ebpEncoding, &ebp.SapType); err != nil {
-			return nil, err
-		}
-		remaining -= uint8(1)
+		ebp.SapType = data[index]
+		index += uint8(1)
 	}
 
 	if ebp.GroupingFlag() {
-		if err = binary.Read(data, ebpEncoding, &ebp.Grouping); err != nil {
-			return nil, err
-		}
-		remaining -= uint8(1)
+		ebp.Grouping = data[index]
+		index += uint8(1)
 	}
 
 	if ebp.TimeFlag() {
-		if err = binary.Read(data, ebpEncoding, &ebp.TimeSeconds); err != nil {
-			return nil, err
-		}
-		if err = binary.Read(data, ebpEncoding, &ebp.TimeFraction); err != nil {
-			return nil, err
-		}
-		remaining -= uint8(8)
+		ebp.TimeSeconds = binary.BigEndian.Uint32(data[index : index+4])
+		index += uint8(4)
+
+		ebp.TimeFraction = binary.BigEndian.Uint32(data[index : index+4])
+		index += uint8(4)
 	}
 
-	if remaining > 0 {
-		ebp.ReservedBytes = make([]byte, remaining)
-		if err = binary.Read(data, ebpEncoding, &ebp.ReservedBytes); err != nil {
-			return nil, err
+	if index < ebp.DataFieldLength+2 {
+		if int(ebp.DataFieldLength+2) > len(data) {
+			return nil, gots.ErrInvalidEBPLength
 		}
-
+		ebp.ReservedBytes = data[index : ebp.DataFieldLength+2]
 	}
 
 	// update the successful read time

--- a/ebp/comcastebp_test.go
+++ b/ebp/comcastebp_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestParseComcastEBP(t *testing.T) {
 	// Read a valid EBP
-	ebp, err := readComcastEbp(bytes.NewBuffer(ComcastEBPBytes[1:]))
+	ebp, err := readComcastEbp(ComcastEBPBytes)
 	if err != nil {
 		t.Errorf("readComcastEbp() returned not null error on valid EBP %v", err)
 	}
@@ -73,7 +73,7 @@ func TestParseComcastEBP(t *testing.T) {
 	}
 
 	// Read an EBP with 0 length
-	ebp, err = readComcastEbp(bytes.NewBuffer([]byte{0x00}))
+	ebp, err = readComcastEbp([]byte{ComcastEbpTag, 0x00})
 	if err != nil {
 		t.Errorf("readComcastEbp() returned error %v on valid EBP", err)
 	}
@@ -82,7 +82,7 @@ func TestParseComcastEBP(t *testing.T) {
 	}
 
 	// Read an EBP with an invalid length
-	ebp, err = readComcastEbp(bytes.NewBuffer([]byte{0xff}))
+	ebp, err = readComcastEbp([]byte{ComcastEbpTag, 0xff})
 	if err == nil {
 		t.Errorf("readComcastEbp() returned null error %v on invalid EBP", err)
 	}

--- a/ebp/ebp.go
+++ b/ebp/ebp.go
@@ -26,9 +26,9 @@ package ebp
 
 import (
 	"encoding/binary"
-	"github.com/Comcast/gots"
-	"io"
 	"time"
+
+	"github.com/Comcast/gots"
 )
 
 // EBP tags
@@ -103,13 +103,12 @@ type baseEbp struct {
 
 // ReadEncoderBoundaryPoint parses and creates an EncoderBoundaryPoint from the given
 // reader. If the bytes do not conform to a know EBP type, an error is returned.
-func ReadEncoderBoundaryPoint(data io.Reader) (ebp EncoderBoundaryPoint, err error) {
-	dataFieldTag := []byte{byte(0)}
-	if _, err := data.Read(dataFieldTag); err != nil {
-		return nil, err
+func ReadEncoderBoundaryPoint(data []byte) (ebp EncoderBoundaryPoint, err error) {
+	if len(data) == 0 {
+		return nil, gots.ErrNoEBPData
 	}
 
-	switch dataFieldTag[0] {
+	switch data[0] {
 	case ComcastEbpTag:
 		ebp, err = readComcastEbp(data)
 	case CableLabsEbpTag:

--- a/ebp/ebp_test.go
+++ b/ebp/ebp_test.go
@@ -24,8 +24,6 @@ SOFTWARE.
 package ebp
 
 import (
-	"bytes"
-	"io"
 	"testing"
 	"time"
 
@@ -57,7 +55,7 @@ var ComcastEBPBytes = []byte{
 	0x04, 0x05} // Reserved
 
 func TestReadEncoderBoundaryPoint(t *testing.T) {
-	ebp, err := ReadEncoderBoundaryPoint(bytes.NewBuffer(CableLabsEBPBytes))
+	ebp, err := ReadEncoderBoundaryPoint(CableLabsEBPBytes)
 	if err != nil {
 		t.Errorf("ReadEncoderBoundaryPoint() returned error on valid: %v", err)
 	}
@@ -65,7 +63,7 @@ func TestReadEncoderBoundaryPoint(t *testing.T) {
 		t.Errorf("ReadEncoderBoundaryPoint() read wrong type of EBP")
 	}
 
-	ebp, err = ReadEncoderBoundaryPoint(bytes.NewBuffer(ComcastEBPBytes))
+	ebp, err = ReadEncoderBoundaryPoint(ComcastEBPBytes)
 	if err != nil {
 		t.Errorf("ReadEncoderBoundaryPoint() returned error on valid: %v", err)
 	}
@@ -73,14 +71,14 @@ func TestReadEncoderBoundaryPoint(t *testing.T) {
 		t.Errorf("ReadEncoderBoundaryPoint() read wrong type of EBP")
 	}
 
-	ebp, err = ReadEncoderBoundaryPoint(bytes.NewBuffer([]byte{0xAB}))
+	ebp, err = ReadEncoderBoundaryPoint([]byte{0xAB})
 	if err != gots.ErrUnrecognizedEbpType {
 		t.Errorf("ReadEncoderBoundaryPoint() read wrong type of EBP")
 	}
 
-	ebp, err = ReadEncoderBoundaryPoint(bytes.NewBuffer([]byte{}))
-	if err != io.EOF {
-		t.Errorf("ReadEncoderBoundaryPoint() should have returned io.EOF")
+	ebp, err = ReadEncoderBoundaryPoint([]byte{})
+	if err != gots.ErrNoEBPData {
+		t.Errorf("ReadEncoderBoundaryPoint() should have returned gots.ErrNoEBPData")
 	}
 }
 

--- a/errors.go
+++ b/errors.go
@@ -33,6 +33,10 @@ var (
 	ErrUnrecognizedEbpType = errors.New("unrecognized EBP")
 	// ErrNoEBP is returned when an attempt is made to extract an EBP from a packet that does not contain one
 	ErrNoEBP = errors.New("packet does not contain EBP")
+	// ErrNoEBPData is returned when an attempt is made to extract an EBP data that does not contain one
+	ErrNoEBPData = errors.New("empty data provided to EBP parser")
+	// ErrInvalidEBPLength is returned when an attempt is made to extract an EBP from a packet that contains an invalid amount of data
+	ErrInvalidEBPLength = errors.New("invalid EBP data length")
 	// ErrInvalidPacketLength denotes an packet length that is not packet.PacketSize bytes in length
 	ErrInvalidPacketLength = errors.New("invalid packet length")
 	// ErrInvalidTSCFlag is returned when the transport scrambling control bit is set to the bit reserved by the specification


### PR DESCRIPTION
There are two major reasons for this change.
1. Almost all the function in gots either extract data from a packet or byte slice.
2. Everytime we call this function in either of the projects we us it in our data is already of type []byte from the function `adaptationfield.EncoderBoundaryPoint(pkt)`. Converting the resulting data into a binary.Reader() copies all of the data and is very slow. So much so that it shows up as a major contributor of CPU usage when profiling these applications. This fixes that issue.

So instead of using a binary.Reader just index the already available bytes.