### PR TITLE
Handle case where PAT section length is too small

### DIFF
--- a/psi/pat.go
+++ b/psi/pat.go
@@ -75,6 +75,9 @@ func NewPAT(patBytes []byte) (PAT, error) {
 // NumPrograms returns the number of programs in this PAT
 func (pat pat) NumPrograms() int {
 	sectionLength := int(SectionLength(pat))
+	if len(pat[:]) < sectionLength {
+		sectionLength = len(pat[:])
+	}
 	numPrograms := int((sectionLength -
 		2 - // Transport Stream ID
 		1 - // Reserved|VersionNumber|CurrentNextIndicator

--- a/psi/pat.go
+++ b/psi/pat.go
@@ -74,7 +74,7 @@ func NewPAT(patBytes []byte) (PAT, error) {
 
 // NumPrograms returns the number of programs in this PAT
 func (pat pat) NumPrograms() int {
-	sectionLength := SectionLength(pat)
+	sectionLength := int(SectionLength(pat))
 	numPrograms := int((sectionLength -
 		2 - // Transport Stream ID
 		1 - // Reserved|VersionNumber|CurrentNextIndicator


### PR DESCRIPTION
There are cases where the subscription math causes the uint16 to wrap around.
Casting it to an int prevents this from happening