### PR TITLE
Handle cases where the accumulator buffer is empty

### DIFF
--- a/psi/pmt.go
+++ b/psi/pmt.go
@@ -63,6 +63,10 @@ type pmt struct {
 // PmtAccumulatorDoneFunc is a doneFunc that can be used for packet accumulation
 // to create a PMT
 func PmtAccumulatorDoneFunc(b []byte) (bool, error) {
+	if len(b) < 1 {
+		return false, nil
+	}
+
 	start := 1 + int(PointerField(b))
 	if len(b) < start {
 		return false, nil


### PR DESCRIPTION
We found this panic in the wild:

```
goroutine 35 [running]:
github.com/Comcast/gots/psi.PointerField(...)
	.../psi/psi.go:36
github.com/Comcast/gots/psi.PmtAccumulatorDoneFunc(0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	.../psi/pmt.go:66 +0xf8
github.com/Comcast/gots/packet.(*accumulator).Add(0xc000159aa0, 0xc000206000, 0xbc, 0xbc, 0x1410400, 0x15fffff, 0xc000081c50)
	.../packet/accumulator.go:86 +0x13a
```