### PR TITLE
Add dolbyvision support.

### DIFF
--- a/psi/pmtdescriptor.go
+++ b/psi/pmtdescriptor.go
@@ -25,8 +25,10 @@ SOFTWARE.
 package psi
 
 import (
+	"encoding/binary"
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // Program Element Stream Descriptor Type.
@@ -43,6 +45,7 @@ const (
 	AVC_VIDEO          uint8 = 40  // 0010 1000 (0x28)
 	STREAM_IDENTIFIER  uint8 = 82  // 0101 0010 (0x52)
 	SCTE_ADAPTATION    uint8 = 151 // 1001 0111 (0x97)
+	DOLBY_VISION       uint8 = 176 // 1011 0000 (0xB0)
 	EBP                uint8 = 233 // 1110 1001 (0xE9)
 	EC3                uint8 = 204 // 1100 1100 (0xCC)
 )
@@ -59,6 +62,8 @@ type PmtDescriptor interface {
 	DecodeIso639LanguageCode() string
 	DecodeIso639AudioType() byte
 	IsDolbyATMOS() bool
+	IsDolbyVision() bool
+	DecodeDolbyVisionCodec(string) string
 }
 
 type pmtDescriptor struct {
@@ -111,6 +116,8 @@ func (descriptor *pmtDescriptor) decode() string {
 		return fmt.Sprintf("Dolby Digital (%d)", descriptor.tag)
 	case SCTE_ADAPTATION:
 		return fmt.Sprintf("SCTE Adaptation (%d)", descriptor.tag)
+	case DOLBY_VISION:
+		return fmt.Sprintf("Dolby Vision (%d)", descriptor.tag)
 	case EBP:
 		return fmt.Sprintf("EBP (%d)", descriptor.tag)
 	case STREAM_IDENTIFIER:
@@ -272,4 +279,39 @@ func (descriptor *pmtDescriptor) IsDolbyATMOS() bool {
 		}
 	}
 	return false
+}
+
+// Check if the registration data is set to `DOVI`
+// dolby-vision-bitstreams-in-mpeg-2-transport-stream-multiplex-v1.2, Section 3.1
+func (descriptor *pmtDescriptor) IsDolbyVision() bool {
+	if descriptor.tag == REGISTRATION {
+		if len(descriptor.data) >= 4 {
+			return binary.BigEndian.Uint32(descriptor.data[:4]) == 0x444F5649
+		}
+	}
+	return false
+}
+
+// Parse the profile and level of dolby vision
+// dolby-vision-bitstreams-in-mpeg-2-transport-stream-multiplex-v1.2, Section 3.3
+func (descriptor *pmtDescriptor) DecodeDolbyVisionCodec(originalCodec string) string {
+	if descriptor.tag == DOLBY_VISION && len(descriptor.data) >= 4 {
+		num := binary.BigEndian.Uint16(descriptor.data[2:4])
+		dv_profile := uint8((num & 0xFE00) >> 9)
+		dv_level := uint8((num & 0xFC) >> 3)
+
+		// default to hvc1
+		baseCodec := "dvh1"
+		// otherwise
+		if strings.Contains(originalCodec, "hev1") {
+			baseCodec = "dvhe"
+		} else if strings.Contains(originalCodec, "avc3") {
+			baseCodec = "dvav"
+		} else if strings.Contains(originalCodec, "avc1") {
+			baseCodec = "dva1"
+		}
+
+		return fmt.Sprintf("%s.%d.%d", baseCodec, dv_profile, dv_level)
+	}
+	return ""
 }


### PR DESCRIPTION
Add dolby vision descriptor support via:
https://www.dolby.com/us/en/technologies/dolby-vision/dolby-vision-for-creative-professionals.html#5

Specifically:
https://www.dolby.com/us/en/technologies/dolby-vision/dolby-vision-profiles-levels_v1.3.1.1.pdf
https://www.dolby.com/us/en/technologies/dolby-vision/dolby-vision-bitstreams-in-mpeg-2-transport-stream-multiplex-v1.2.pdf
https://www.dolby.com/us/en/technologies/dolby-vision/dolby-vision-streams-within-the-mpeg-dash-format-v2.0.pdf