### PR TITLE
Include recent versions of go in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: go
 sudo: false
 matrix:
   include:
+    - go: "1.13"
+    - go: "1.12"
+    - go: "1.11"
     - go: "1.10"
       env: LATEST=true
     - go: "1.5"


### PR DESCRIPTION
This will build with go 1.11, 1.12, and 1.13. If a build fails with any of those Go versions, the build will fail. The binary releases, however, are still released with Go 1.10, because I can't know who need what version for release.