### PR TITLE
Hardcode DV codec string because it is mostly meaningless in MPEG2-TS

### DIFF
--- a/psi/pmtdescriptor.go
+++ b/psi/pmtdescriptor.go
@@ -299,18 +299,10 @@ func (descriptor *pmtDescriptor) DecodeDolbyVisionCodec(originalCodec string) st
 		dv_profile := uint8((num & 0xFE00) >> 9)
 		dv_level := uint8((num & 0xFC) >> 3)
 
-		// Hardcode to dvhe because MPEG-2 TS doesn't support hevc
+		// Hardcode to dvhe because this is MPEG2-TS which doesn't support h265
+		// The codec strings of dvc1 vs dvhe is an mp4 specific thing
+		// dolby-vision-streams-within-the-mpeg-dash-format-v2.0 see Table 2, section 4.2.3
 		baseCodec := "dvhe"
-		// // default to hvc1
-		// baseCodec := "dvh1"
-		// // otherwise
-		// if strings.Contains(originalCodec, "hev1") {
-		// 	baseCodec = "dvhe"
-		// } else if strings.Contains(originalCodec, "avc3") {
-		// 	baseCodec = "dvav"
-		// } else if strings.Contains(originalCodec, "avc1") {
-		// 	baseCodec = "dva1"
-		// }
 
 		return fmt.Sprintf("%s.%02d.%02d", baseCodec, dv_profile, dv_level)
 	}

--- a/psi/pmtdescriptor.go
+++ b/psi/pmtdescriptor.go
@@ -28,7 +28,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"strconv"
-	"strings"
 )
 
 // Program Element Stream Descriptor Type.
@@ -300,18 +299,20 @@ func (descriptor *pmtDescriptor) DecodeDolbyVisionCodec(originalCodec string) st
 		dv_profile := uint8((num & 0xFE00) >> 9)
 		dv_level := uint8((num & 0xFC) >> 3)
 
-		// default to hvc1
-		baseCodec := "dvh1"
-		// otherwise
-		if strings.Contains(originalCodec, "hev1") {
-			baseCodec = "dvhe"
-		} else if strings.Contains(originalCodec, "avc3") {
-			baseCodec = "dvav"
-		} else if strings.Contains(originalCodec, "avc1") {
-			baseCodec = "dva1"
-		}
+		// Hardcode to dvhe because MPEG-2 TS doesn't support hevc
+		baseCodec := "dvhe"
+		// // default to hvc1
+		// baseCodec := "dvh1"
+		// // otherwise
+		// if strings.Contains(originalCodec, "hev1") {
+		// 	baseCodec = "dvhe"
+		// } else if strings.Contains(originalCodec, "avc3") {
+		// 	baseCodec = "dvav"
+		// } else if strings.Contains(originalCodec, "avc1") {
+		// 	baseCodec = "dva1"
+		// }
 
-		return fmt.Sprintf("%s.%d.%d", baseCodec, dv_profile, dv_level)
+		return fmt.Sprintf("%s.%02d.%02d", baseCodec, dv_profile, dv_level)
 	}
 	return ""
 }


### PR DESCRIPTION
SO. It seems TS was never meant to support h265, and my attempt to adhere to the spec regarding Dolby Vision was meaningless. These codec strings map to mp4 properties, and it has been determined that we only need the one codec string.