### PR TITLE
Fixed CreateSpliceInsertCommand and CreateTimeSignalCommand functions

### DIFF
--- a/scte35/splicecommandmodify.go
+++ b/scte35/splicecommandmodify.go
@@ -38,7 +38,7 @@ func CreateSpliceInsertCommand() SpliceInsertCommand {
 }
 
 // CreateTimeSignalCommand will create a default TimeSignalCommand
-func CreateTimeSignalCommand() SpliceCommand {
+func CreateTimeSignalCommand() TimeSignalCommand {
 	return &timeSignal{}
 }
 

--- a/scte35/splicecommandmodify.go
+++ b/scte35/splicecommandmodify.go
@@ -29,7 +29,7 @@ import (
 )
 
 // CreateSpliceInsertCommand will create a default SpliceInsertCommand.
-func CreateSpliceInsertCommand() SpliceCommand {
+func CreateSpliceInsertCommand() SpliceInsertCommand {
 	return &spliceInsert{
 		// enable this to have less variable sized fields by
 		// default, do not use component splice mode by default


### PR DESCRIPTION
CreateSpliceInsertCommand and CreateTimeSignalCommand returns by default SpliceCommand.
SpliceCommand allows us to read-only signal values. This fix returns designated (I guess) interfaces that allow modifying created signals outside the module.