### PR TITLE
When we are trying to close a descriptor here, we close all the signa…

### DIFF
--- a/scte35/state.go
+++ b/scte35/state.go
@@ -211,8 +211,13 @@ func (s *state) Close(desc SegmentationDescriptor) ([]SegmentationDescriptor, er
 		d := s.open[i]
 		closed = append(closed, d)
 		if desc.Equal(d) {
-			// found our descriptor, remove it and everything after it
-			s.open = s.open[0:i]
+			// found our descriptor at index i, remove it
+			// Shift s.open left by one index.
+			copy(s.open[i:], s.open[i+1:])
+			// Delete last element
+			s.open[len(s.open)-1] = nil
+			// Truncate slice
+			s.open = s.open[:len(s.open)-1]
 			return closed, nil
 		}
 	}

--- a/scte35/state.go
+++ b/scte35/state.go
@@ -209,7 +209,6 @@ func (s *state) Close(desc SegmentationDescriptor) ([]SegmentationDescriptor, er
 	var closed []SegmentationDescriptor
 	for i := len(s.open) - 1; i >= 0; i-- {
 		d := s.open[i]
-		closed = append(closed, d)
 		if desc.Equal(d) {
 			// found our descriptor at index i, remove it
 			// Shift s.open left by one index.
@@ -218,6 +217,7 @@ func (s *state) Close(desc SegmentationDescriptor) ([]SegmentationDescriptor, er
 			s.open[len(s.open)-1] = nil
 			// Truncate slice
 			s.open = s.open[:len(s.open)-1]
+			closed = append(closed, d)
 			return closed, nil
 		}
 	}


### PR DESCRIPTION
…ls after the signal we actually want to close, which is not ideal. Updated workflow and logic to only remove the signal we want to close.

For example:
if our open list has: 0x34, 0x36
And we want to close 0x34 as it expires, the old code would delete both of these signals from the open list, and the next 0x37s would throw a warning. Also this would cause 0x36 to be around in the mpd for forever.