### PR TITLE
Fix handling of otherDescriptors

### DIFF
--- a/scte35/scte35.go
+++ b/scte35/scte35.go
@@ -153,6 +153,7 @@ func (s *scte35) parseTable(data []byte) error {
 				// Not interested in descriptors that are not
 				// SegmentationDescriptors
 				// Store their bytes anyways so the data is not lost.
+				s.otherDescriptorBytes = append(s.otherDescriptorBytes, descTag, descLen)
 				s.otherDescriptorBytes = append(s.otherDescriptorBytes, buf.Next(int(descLen))...)
 			} else {
 				d := &segmentationDescriptor{spliceInfo: s}


### PR DESCRIPTION
When reading a tag, otherDescriptors are stored in a buffer. 
Also store descriptor tag and len in the buffer. Otherwise, the modified SCTE35 will be broken.
