### PR TITLE
Set pids to ints from uint16

### DIFF
--- a/cli/parsefile.go
+++ b/cli/parsefile.go
@@ -92,7 +92,7 @@ func main() {
 	var pkt packet.Packet
 	var numPackets uint64
 	ebps := make(map[uint64]ebp.EncoderBoundaryPoint)
-	scte35PIDs := make(map[uint16]bool)
+	scte35PIDs := make(map[int]bool)
 	if *dumpSCTE35 {
 		for _, pmt := range pmts {
 			for _, es := range pmt.ElementaryStreams() {
@@ -147,7 +147,7 @@ func main() {
 			fmt.Printf("Packet %d contains EBP %+v\n\n", numPackets, boundaryPoint)
 		}
 		if *showPacketNumberOfPID != 0 {
-			pid := uint16(*showPacketNumberOfPID)
+			pid := *showPacketNumberOfPID
 			pktPid := packet.Pid(&pkt)
 			if pktPid == pid {
 				fmt.Printf("First Packet of PID %d contents: %x\n", pid, pkt)
@@ -158,7 +158,7 @@ func main() {
 	fmt.Println()
 }
 
-func printSCTE35(pid uint16, msg scte35.SCTE35) {
+func printSCTE35(pid int, msg scte35.SCTE35) {
 	fmt.Printf("SCTE35 Message on PID %d\n", pid)
 	printSpliceCommand(msg.CommandInfo())
 
@@ -204,7 +204,7 @@ func printSpliceInsertCommand(insert scte35.SpliceInsertCommand) {
 	}
 }
 
-func printPmt(pn uint16, pmt psi.PMT) {
+func printPmt(pn int, pmt psi.PMT) {
 	fmt.Printf("Program #%v PMT\n", pn)
 	fmt.Printf("\tPIDs %v\n", pmt.Pids())
 	fmt.Println("\tElementary Streams")

--- a/packet/create.go
+++ b/packet/create.go
@@ -79,7 +79,7 @@ var (
 //              WithContinuousAF,
 //              WithPUSI),
 //        cc)
-func Create(pid uint16, options ...func(*Packet)) *Packet {
+func Create(pid int, options ...func(*Packet)) *Packet {
 	var pkt Packet
 	setPid(&pkt, pid)
 	for _, option := range options {
@@ -93,7 +93,7 @@ func Create(pid uint16, options ...func(*Packet)) *Packet {
 
 // CreateTestPacket creates a test packet with the given PID, continuity counter, payload unit start indicator and payload flag
 // This is a convenience function for often used packet creatio options functions
-func CreateTestPacket(pid uint16, cc uint8, pusi, hasPay bool) *Packet {
+func CreateTestPacket(pid int, cc uint8, pusi, hasPay bool) *Packet {
 	var pkt *Packet
 	if hasPay && pusi {
 		pkt = SetCC(
@@ -116,13 +116,13 @@ func CreateTestPacket(pid uint16, cc uint8, pusi, hasPay bool) *Packet {
 }
 
 // CreateDCPacket creates a new packet with a discontinuous adapataion field and the given PID and CC
-func CreateDCPacket(pid uint16, cc uint8) *Packet {
+func CreateDCPacket(pid int, cc uint8) *Packet {
 	pkt := SetCC(Create(pid, WithDiscontinuousAF, WithHasPayloadFlag), cc)
 	return pkt
 }
 
 // CreatePacketWithPayload creates a new packet with the given PID, CC and payload
-func CreatePacketWithPayload(pid uint16, cc uint8, pay []byte) *Packet {
+func CreatePacketWithPayload(pid int, cc uint8, pay []byte) *Packet {
 	pkt := SetCC(
 		Create(
 			pid,
@@ -137,7 +137,7 @@ func CreatePacketWithPayload(pid uint16, cc uint8, pay []byte) *Packet {
 	return pkt
 }
 
-func setPid(pkt *Packet, pid uint16) {
+func setPid(pkt *Packet, pid int) {
 	pkt[1] = byte(pid >> 8 & 0x1f)
 	pkt[2] = byte(pid & 0xff)
 }

--- a/packet/modify_test.go
+++ b/packet/modify_test.go
@@ -554,7 +554,7 @@ func BenchmarkOldStyleCreate(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		SetCC(
 			Create(
-				uint16(13),
+				13,
 				WithHasPayloadFlag,
 				WithPUSI),
 			7)

--- a/packet/packet.go
+++ b/packet/packet.go
@@ -58,8 +58,8 @@ func PayloadUnitStartIndicator(packet *Packet) bool {
 // PID is the Packet Identifier.  Each table or elementary stream in the
 // transport stream is identified by a PID.  The PID is contained in the 13
 // bits that span the last 5 bits of second byte and all bits in the byte.
-func Pid(packet *Packet) uint16 {
-	return uint16(packet[1]&0x1f)<<8 | uint16(packet[2])
+func Pid(packet *Packet) int {
+	return int(packet[1]&0x1f)<<8 | int(packet[2])
 }
 
 // ContainsPayload is a flag that indicates the packet has a payload.  The flag is

--- a/packet/packet_test.go
+++ b/packet/packet_test.go
@@ -80,7 +80,7 @@ func TestPid(t *testing.T) {
 			"79279065d30a93c8d5584d12b87b35938e18f2868f149f3dec38cae665db77bd" +
 			"0ba9b7a659363d7347d22f835b4e53f6472f01be53d7df28ea7f1764972f5549" +
 			"34096bd6bf42eabe1dff1c59e0cc55a716b6a40618b3305b45779c31")
-	expected := uint16(102)
+	expected := 102
 	if pid := Pid(packet); pid != expected {
 		t.Errorf("Pid() = %d, want %d", pid, expected)
 	}
@@ -94,7 +94,7 @@ func TestPidGreaterThan255(t *testing.T) {
 			"79279065d30a93c8d5584d12b87b35938e18f2868f149f3dec38cae665db77bd" +
 			"0ba9b7a659363d7347d22f835b4e53f6472f01be53d7df28ea7f1764972f5549" +
 			"34096bd6bf42eabe1dff1c59e0cc55a716b6a40618b3305b45779c31")
-	expected := uint16(290)
+	expected := 290
 	if pid := Pid(packet); pid != expected {
 		t.Errorf("Pid() = %d, want %d", pid, expected)
 	}

--- a/psi/pat.go
+++ b/psi/pat.go
@@ -34,14 +34,14 @@ import (
 
 const (
 	// PatPid is the PID of a PAT. By definition this value is zero.
-	PatPid = uint16(0)
+	PatPid = 0
 )
 
 // PAT interface represents operations on a Program Association Table. Currently only single program transport streams (SPTS)are supported
 type PAT interface {
 	NumPrograms() int
-	ProgramMap() map[uint16]uint16
-	SPTSpmtPID() (uint16, error)
+	ProgramMap() map[int]int
+	SPTSpmtPID() (int, error)
 }
 
 // The Program Association Table (PAT) lists the programs available in transport
@@ -89,16 +89,16 @@ func (pat pat) NumPrograms() int {
 }
 
 // ProgramMap returns a map of program numbers and PIDs of the PMTs
-func (pat pat) ProgramMap() map[uint16]uint16 {
-	m := make(map[uint16]uint16)
+func (pat pat) ProgramMap() map[int]int {
+	m := make(map[int]int)
 
 	counter := 8 // skip table id et al
 
 	for i := 0; i < pat.NumPrograms(); i++ {
-		pn := (uint16(pat[counter+1]) << 8) | uint16(pat[counter+2])
+		pn := (int(pat[counter+1]) << 8) | int(pat[counter+2])
 
 		// ignore the top three (reserved) bits
-		pid := uint16(pat[counter+3])&0x1f<<8 | uint16(pat[counter+4])
+		pid := int(pat[counter+3])&0x1f<<8 | int(pat[counter+4])
 
 		// A value of 0 is reserved for a NIT packet identifier.
 		if pn > 0 {
@@ -112,7 +112,7 @@ func (pat pat) ProgramMap() map[uint16]uint16 {
 }
 
 // SPTSpmtPID returns the PMT PID if and only if this pat is for a single program transport stream. If this pat is for a multiprogram transport stream, an error is returned.
-func (pat pat) SPTSpmtPID() (uint16, error) {
+func (pat pat) SPTSpmtPID() (int, error) {
 	if pat.NumPrograms() > 1 {
 		return 0, errors.New("Not a single program transport stream")
 	}

--- a/psi/pat_test.go
+++ b/psi/pat_test.go
@@ -34,12 +34,12 @@ import (
 var testData = []struct {
 	patBytes          string
 	wantStreams       int
-	wantProgramNumber uint16
-	wantProgramMapPID uint16
-	wantProgramMap    map[uint16]uint16
+	wantProgramNumber int
+	wantProgramMapPID int
+	wantProgramMap    map[int]int
 }{
-	{"0000b00d0000c100000001e064dee0f320", 1, 1, 100, map[uint16]uint16{1: 100}},
-	{"0000b0150000c100000001e0640002e0c80003e12ce8f16345", 3, 0, 8192, map[uint16]uint16{1: 100, 2: 200, 3: 300}},
+	{"0000b00d0000c100000001e064dee0f320", 1, 1, 100, map[int]int{1: 100}},
+	{"0000b0150000c100000001e0640002e0c80003e12ce8f16345", 3, 0, 8192, map[int]int{1: 100, 2: 200, 3: 300}},
 }
 
 func TestNumPrograms(t *testing.T) {
@@ -121,7 +121,7 @@ func TestReadPATForSmoke(t *testing.T) {
 	}
 	// sanity check (tests integration a bit)
 	gotMap := pat.ProgramMap()
-	wantMap := map[uint16]uint16{1: 598}
+	wantMap := map[int]int{1: 598}
 	if !reflect.DeepEqual(wantMap, gotMap) {
 		t.Errorf("PAT read is invalid, did not have expected program map")
 	}

--- a/psi/pmt_test.go
+++ b/psi/pmt_test.go
@@ -47,12 +47,12 @@ func parseHexString(h string) *packet.Packet {
 }
 
 type testPmtElementaryStream struct {
-	elementaryPid       uint16
+	elementaryPid       int
 	streamType          uint8
 	presentationLagsEbp bool
 }
 
-func (es *testPmtElementaryStream) ElementaryPid() uint16 {
+func (es *testPmtElementaryStream) ElementaryPid() int {
 	return es.elementaryPid
 }
 
@@ -112,7 +112,7 @@ func TestParseTable(t *testing.T) {
 		t.Errorf("Can't parse PMT table %v", err)
 	}
 
-	want := []uint16{101, 102, 110}
+	want := []int{101, 102, 110}
 	got := pmt.Pids()
 	if len(want) != len(got) {
 		t.Errorf("ES count does not match want:%v got:%v", len(want), len(got))
@@ -141,7 +141,7 @@ func TestParseMultipleTables(t *testing.T) {
 		t.Errorf("Can't parse PMT table %v", err)
 	}
 
-	want := []uint16{101, 102, 110}
+	want := []int{101, 102, 110}
 	got := pmt.Pids()
 	if len(want) != len(got) {
 		t.Errorf("ES count does not match want:%v got:%v", len(want), len(got))
@@ -181,7 +181,7 @@ func TestBuildPMT(t *testing.T) {
 		t.Error(err)
 	}
 
-	want := []uint16{101, 102, 110}
+	want := []int{101, 102, 110}
 	got := pmt.Pids()
 	if len(want) != len(got) {
 		t.Errorf("PID lengths do not match Expected %d: Got %d", len(want), len(got))
@@ -271,7 +271,7 @@ func TestBuildPMT_LargePointerFieldGood(t *testing.T) {
 		t.Error(err)
 	}
 
-	want := []uint16{101, 102, 110}
+	want := []int{101, 102, 110}
 	got := pmt.Pids()
 	if len(want) != len(got) {
 		t.Errorf("PID lengths do not match Expected %d: Got %d", len(want), len(got))
@@ -320,7 +320,7 @@ func TestBuildMultiPacketPMT(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	wantedPids := []uint16{101, 102, 103, 104, 105, 220}
+	wantedPids := []int{101, 102, 103, 104, 105, 220}
 	if len(wantedPids) != len(pmt.Pids()) {
 		t.Errorf("PID length do not match expected %d Got %d", len(wantedPids), len(pmt.Pids()))
 		t.FailNow()
@@ -377,7 +377,7 @@ func TestBuildMultiPacketPMT2(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	wantedPids := []uint16{481, 482, 483, 484, 488, 489, 490, 494, 495, 496, 500}
+	wantedPids := []int{481, 482, 483, 484, 488, 489, 490, 494, 495, 496, 500}
 	if len(wantedPids) != len(pmt.Pids()) {
 		t.Errorf("PID length do not match expected %d Got %d", len(wantedPids), len(pmt.Pids()))
 		t.FailNow()
@@ -397,7 +397,7 @@ func TestBuildMultiPacketPMT2(t *testing.T) {
 }
 
 func TestElementaryStreams(t *testing.T) {
-	pids := []uint16{101, 102, 103}
+	pids := []int{101, 102, 103}
 	want := []PmtElementaryStream{
 		&testPmtElementaryStream{101, 27, true},
 		&testPmtElementaryStream{102, 15, true},
@@ -412,13 +412,13 @@ func TestElementaryStreams(t *testing.T) {
 			t.Errorf("PIDs do not match Want %d: Got %d", es.ElementaryPid(), got[i].ElementaryPid())
 		}
 	}
-	pid := uint16(102)
+	pid := int(102)
 	if !pmt.IsPidForStreamWherePresentationLagsEbp(pid) {
 		t.Errorf("PID %d: presentation should lag EBP", pid)
 	}
 }
 func TestIsPidForStreamWherePresentationLagsEbp(t *testing.T) {
-	pids := []uint16{101, 102, 103}
+	pids := []int{101, 102, 103}
 	streams := []PmtElementaryStream{&testPmtElementaryStream{102, 15, true}}
 	pmt := &pmt{pids: pids, elementaryStreams: streams}
 	if !pmt.IsPidForStreamWherePresentationLagsEbp(102) {
@@ -427,7 +427,7 @@ func TestIsPidForStreamWherePresentationLagsEbp(t *testing.T) {
 }
 
 func TestIsNotPidForStreamWherePresentationLagsEbp(t *testing.T) {
-	pids := []uint16{101, 102, 103}
+	pids := []int{101, 102, 103}
 	streams := []PmtElementaryStream{&testPmtElementaryStream{102, 15, false}}
 	pmt := &pmt{pids: pids, elementaryStreams: streams}
 
@@ -540,7 +540,7 @@ func TestFilterPMTPacketsToPids_MultiPacketPMT(t *testing.T) {
 		t.Error(err)
 	}
 
-	wantedPids := []uint16{101, 102, 103, 104, 105, 220}
+	wantedPids := []int{101, 102, 103, 104, 105, 220}
 
 	filteredPids := wantedPids[:len(wantedPids)-1]
 	filteredPMTPackets, err := FilterPMTPacketsToPids([]*packet.Packet{firstPacketBytes, secondPacketBytes}, filteredPids)
@@ -553,7 +553,7 @@ func TestFilterPMTPacketsToPids_MultiPacketPMT(t *testing.T) {
 		acc.Add(p[:])
 	}
 
-	wantedPids = []uint16{101, 102, 103, 104, 105}
+	wantedPids = []int{101, 102, 103, 104, 105}
 	payload, err = acc.Parse()
 	if err != nil {
 		t.Error(err)
@@ -591,7 +591,7 @@ func TestFilterPMTPacketsToPids_PIDNotFound(t *testing.T) {
 	}
 
 	// Test when some of the PIDs to be filtered exist in the PMT.
-	pmtPkts, err := FilterPMTPacketsToPids([]*packet.Packet{&pkt}, []uint16{105, 106})
+	pmtPkts, err := FilterPMTPacketsToPids([]*packet.Packet{&pkt}, []int{105, 106})
 	if err.Error() != "PID(s) [106] not found in PMT." {
 		t.Errorf("Expected missing PID error string, got %s", err.Error())
 	}
@@ -601,7 +601,7 @@ func TestFilterPMTPacketsToPids_PIDNotFound(t *testing.T) {
 	}
 
 	// Test when none of the PIDs to be filtered exist in the PMT.
-	pmtPkts, err = FilterPMTPacketsToPids([]*packet.Packet{&pkt}, []uint16{106, 107})
+	pmtPkts, err = FilterPMTPacketsToPids([]*packet.Packet{&pkt}, []int{106, 107})
 	if err.Error() != "PID(s) [106 107] not found in PMT." {
 		t.Errorf("Expected missing PID error string, got %s", err.Error())
 	}
@@ -765,7 +765,7 @@ func TestReadPMTForSmoke(t *testing.T) {
 		"fffffffffffffffffffffffffffffffffffffffffffffffffffff")
 	r := bytes.NewReader(bs)
 
-	pid := uint16(598)
+	pid := 598
 	pmt, err := ReadPMT(r, pid)
 	if err != nil {
 		t.Fatalf("Unexpected error reading PMT: %v", err)
@@ -786,7 +786,7 @@ func TestReadPMTIncomplete(t *testing.T) {
 		"ff4742") // incomplete PMT packet
 	r := bytes.NewReader(bs)
 
-	pid := uint16(598)
+	pid := 598
 	_, err := ReadPMT(r, pid)
 	if err == nil {
 		t.Errorf("Expected to get error reading PMT, but did not")
@@ -809,7 +809,7 @@ func TestReadPMTSCTE(t *testing.T) {
 		"f008bf06496e766964690bcfa64bffff") // two PMT packets, first with SCTE 0xc0 table only
 	r := bytes.NewReader(bs)
 
-	pid := uint16(59)
+	pid := 59
 	pmt, err := ReadPMT(r, pid)
 	if err != nil {
 		t.Errorf("Unexpected error reading PMT: %v", err)
@@ -840,7 +840,7 @@ func TestReadPMT_MultipleTables_MultiplePackets(t *testing.T) {
 		"ffffffffffffffffffffffffffffffff") // two tables (0xc0 and 0x2) combined across two packets
 	r := bytes.NewReader(bs)
 
-	pid := uint16(59)
+	pid := 59
 	pmt, err := ReadPMT(r, pid)
 	if err != nil {
 		t.Errorf("Unexpected error reading PMT: %v", err)

--- a/psi/pmtelementarystream.go
+++ b/psi/pmtelementarystream.go
@@ -32,14 +32,14 @@ import (
 // PmtElementaryStream represents an elementary stream inside a PMT
 type PmtElementaryStream interface {
 	PmtStreamType
-	ElementaryPid() uint16
+	ElementaryPid() int
 	Descriptors() []PmtDescriptor
 	MaxBitRate() uint64
 }
 
 type pmtElementaryStream struct {
 	PmtStreamType
-	elementaryPid uint16
+	elementaryPid int
 	descriptors   []PmtDescriptor
 }
 
@@ -51,7 +51,7 @@ const (
 )
 
 // NewPmtElementaryStream creates a new PmtElementaryStream.
-func NewPmtElementaryStream(streamType uint8, elementaryPid uint16, descriptors []PmtDescriptor) PmtElementaryStream {
+func NewPmtElementaryStream(streamType uint8, elementaryPid int, descriptors []PmtDescriptor) PmtElementaryStream {
 	es := &pmtElementaryStream{}
 	es.PmtStreamType = LookupPmtStreamType(streamType)
 	es.elementaryPid = elementaryPid
@@ -59,7 +59,7 @@ func NewPmtElementaryStream(streamType uint8, elementaryPid uint16, descriptors 
 	return es
 }
 
-func (es *pmtElementaryStream) ElementaryPid() uint16 {
+func (es *pmtElementaryStream) ElementaryPid() int {
 	return es.elementaryPid
 }
 


### PR DESCRIPTION
We process, filter and transform so many packets and uint16s are about 2.55x slower in use. 

For just _accessing_ maps of different types:
BenchmarkMapUint64Keys-16     	292469652	         4.549 ns/op
BenchmarkMapIntKeys-16        	272205794	         4.732 ns/op
BenchmarkMapUintKeys-16       	267450457	         4.410 ns/op
BenchmarkMapInt16Keys-16      	98100704	        12.07 ns/op
BenchmarkMapUint16Keys-16     	92810259	        12.22 ns/op

let alone all the converting back and forth we have to do. 

I am standardizing pids on ints; they are easier as a default and faster.

or if you want to explore the golang source code:
https://github.com/golang/go/blob/dc12d5b0f5e9c1cfec2a8eb6dd7ff3473c36d45c/src/runtime/map_fast32.go#L12
https://github.com/golang/go/blob/dc12d5b0f5e9c1cfec2a8eb6dd7ff3473c36d45c/src/runtime/map_fast64.go#L12

vs
https://github.com/golang/go/blob/dc12d5b0f5e9c1cfec2a8eb6dd7ff3473c36d45c/src/runtime/map.go

you will not find a fast mapaccess1_fast16 anywhere.