### PR TITLE
Fix off-by-one in range check

### DIFF
--- a/psi/pmt.go
+++ b/psi/pmt.go
@@ -119,7 +119,7 @@ func (p *pmt) parsePMTSection(pmtBytes []byte) error {
 	var elementaryStreams []PmtElementaryStream
 	sectionLength := sectionLength(pmtBytes)
 
-	if len(pmtBytes) < programInfoLengthOffset {
+	if len(pmtBytes) <= programInfoLengthOffset {
 		return gots.ErrParsePMTDescriptor
 	}
 

--- a/psi/pmt.go
+++ b/psi/pmt.go
@@ -119,7 +119,7 @@ func (p *pmt) parsePMTSection(pmtBytes []byte) error {
 	var elementaryStreams []PmtElementaryStream
 	sectionLength := sectionLength(pmtBytes)
 
-	if len(pmtBytes) <= programInfoLengthOffset {
+	if len(pmtBytes) <= programInfoLengthOffset+1 {
 		return gots.ErrParsePMTDescriptor
 	}
 


### PR DESCRIPTION
fixes #148:

```
panic: runtime error: index out of range [10] with length 10

goroutine 182 [running]:
github.com/Comcast/gots/psi.(*pmt).parsePMTSection(0xc004d1a000, 0xc0012af9d4, 0xa, 0x234, 0xc004c5d1a0, 0x6f037f)
	github.com/Comcast/gots@v0.0.0-20201111000122-5e29012f8ad4/psi/pmt.go:126 +0x7d1
github.com/Comcast/gots/psi.(*pmt).parseTables(0xc004d1a000, 0xc0012af700, 0x2e0, 0x508, 0x508, 0x0)
	github.com/Comcast/gots@v0.0.0-20201111000122-5e29012f8ad4/psi/pmt.go:106 +0x10c
github.com/Comcast/gots/psi.NewPMT(0xc0012af700, 0x2e0, 0x508, 0x4, 0x0, 0x0, 0x0)
	github.com/Comcast/gots@v0.0.0-20201111000122-5e29012f8ad4/psi/pmt.go:92 +0x69
```

cc @LimitlessEarth 