### PR TITLE
Pretty print audio_type as hex

### DIFF
--- a/psi/pmt_test.go
+++ b/psi/pmt_test.go
@@ -429,7 +429,7 @@ func TestStringFormat(t *testing.T) {
 		t.Error(err)
 	}
 
-	want := "PMT[ElementaryStream[pid=101,streamType=27,descriptor0='Maximum Bit-Rate (1200)'],ElementaryStream[pid=102,streamType=15,descriptor0='ISO 639 Language (code=eng, audioType=0)'],ElementaryStream[pid=110,streamType=134]]"
+	want := "PMT[ElementaryStream[pid=101,streamType=27,descriptor0='Maximum Bit-Rate (1200)'],ElementaryStream[pid=102,streamType=15,descriptor0='ISO 639 Language (code=eng, audioType=0x00)'],ElementaryStream[pid=110,streamType=134]]"
 	got := fmt.Sprintf("%v", pmt)
 	if want != got {
 		t.Errorf("String format for PMT failed. Want: %s: Got %s", want, got)

--- a/psi/pmtdescriptor.go
+++ b/psi/pmtdescriptor.go
@@ -26,6 +26,7 @@ package psi
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 )
@@ -121,8 +122,8 @@ func (descriptor *pmtDescriptor) Format() string {
 func (descriptor *pmtDescriptor) decode() string {
 	switch descriptor.tag {
 	case LANGUAGE:
-		return fmt.Sprintf("ISO 639 Language (code=%s, audioType=%b)",
-			descriptor.DecodeIso639LanguageCode(), descriptor.DecodeIso639AudioType())
+		return fmt.Sprintf("ISO 639 Language (code=%s, audioType=0x%s)",
+			descriptor.DecodeIso639LanguageCode(), hex.EncodeToString([]byte{descriptor.DecodeIso639AudioType()}))
 	case MAXIMUM_BITRATE:
 		return fmt.Sprintf("Maximum Bit-Rate (%d)", descriptor.DecodeMaximumBitRate())
 	case VIDEO_STREAM:


### PR DESCRIPTION
Print a hex number instead of binary.