### PR TITLE
Fix out of bounds access

### DIFF
--- a/pes/pesheader.go
+++ b/pes/pesheader.go
@@ -170,7 +170,7 @@ func NewPESHeader(pesBytes []byte) (PESHeader, error) {
 	pes := new(pESHeader)
 	var err error
 
-	if CheckLength(pesBytes, "PES", 6) {
+	if CheckLength(pesBytes, "PES", 7) {
 
 		pes.packetStartCodePrefix = uint32(pesBytes[0])<<16 | uint32(pesBytes[1])<<8 | uint32(pesBytes[2])
 


### PR DESCRIPTION
```
runtime.boundsError: runtime error: index out of range [6] with length 6
  File "github.com/Comcast/gots@v0.0.0-20201111000122-5e29012f8ad4/pes/pesheader.go", line 180, in NewPESHeader