### PR TITLE
Add AUDIO_NATIVE audio type

### DIFF
--- a/psi/pmtdescriptor.go
+++ b/psi/pmtdescriptor.go
@@ -57,6 +57,7 @@ const (
 	AUDIO_CLEAN_EFFECTS int = 1   // 0000 0001 (0x01)
 	AUDIO_DESCRIPTION   int = 3   // 0000 0011 (0x03)
 	AUDIO_PRIMARY       int = 128 // 1000 0000 (0x80)
+	AUDIO_NATIVE        int = 129 // 1000 0001 (0x81)
 )
 
 // Descriptor tag extension

--- a/v2/psi/pmtdescriptor.go
+++ b/v2/psi/pmtdescriptor.go
@@ -57,6 +57,7 @@ const (
 	AUDIO_CLEAN_EFFECTS int = 1   // 0000 0001 (0x01)
 	AUDIO_DESCRIPTION   int = 3   // 0000 0011 (0x03)
 	AUDIO_PRIMARY       int = 128 // 1000 0000 (0x80)
+	AUDIO_NATIVE        int = 129 // 1000 0001 (0x81)
 )
 
 // Descriptor tag extension


### PR DESCRIPTION
Adds a new ISO-639 `audio_type` constant (0x81/129) corresponding to native audio.