### PR TITLE
Add 0x44 to the Out/Open descriptor list and 0x45 to the In/closing d…

### DIFF
--- a/scte35/segmentationdescriptor.go
+++ b/scte35/segmentationdescriptor.go
@@ -313,6 +313,7 @@ func (d *segmentationDescriptor) IsOut() bool {
 		SegDescProviderPOStart,
 		SegDescDistributorPOStart,
 		SegDescUnscheduledEventStart,
+		SegDescProviderAdBlockStart,
 		SegDescNetworkStart:
 		return true
 	default:
@@ -336,6 +337,7 @@ func (d *segmentationDescriptor) IsIn() bool {
 		SegDescProviderPOEnd,
 		SegDescDistributorPOEnd,
 		SegDescUnscheduledEventEnd,
+		SegDescProviderAdBlockEnd,
 		SegDescNetworkEnd:
 		return true
 	default:


### PR DESCRIPTION
…escriptor list. Pillar needs this as otherwise it thinks 0x45 is an open event.