### PR TITLE
Add deprecated comment to v1 go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: use github.com/Comcast/gots/v2 instead.
 module github.com/Comcast/gots
 
 go 1.18


### PR DESCRIPTION
Before we update the root Go module to `v2` (which will allow us to do away with `v2/`), I wanted to add a comment to the v1 `go.mod` to indicate that it is no longer supported. The comment will be displayed if anyone attempts to `go get github.com/Comcast/gots`.