### PR TITLE
Update `StreamSwitchSignalId` to return a license rotation bool

### DIFF
--- a/scte35/doc.go
+++ b/scte35/doc.go
@@ -457,7 +457,7 @@ type SegmentationDescriptor interface {
 	SetSubSegmentsExpected(value uint8)
 	// StreamSwitchSignalID returns the signalID of streamswitch signal if
 	// present in the descriptor
-	StreamSwitchSignalId() (string, error)
+	StreamSwitchSignalId() (string, bool, error)
 	// IsOut returns true if a signal is an out
 	IsOut() bool
 	// IsIn returns true if a signal is an in
@@ -482,14 +482,15 @@ type SegmentationDescriptor interface {
 // example code is below.
 // s := scte35.NewState()
 // scte,_ := scte.ParseSCTE35(bytes)
-// for _,d := range(scte.Descriptors()) {
-//   closed = s.ProcessDescriptor(d)
-//   ...handle closed signals appropriately here
-//   if d.HasDuration() {
-//     time.AfterFunc(d.Duration() + someFudgeDelta,
-//                    func() { closed = s.Close(d) })
-//   }
-// }
+//
+//	for _,d := range(scte.Descriptors()) {
+//	  closed = s.ProcessDescriptor(d)
+//	  ...handle closed signals appropriately here
+//	  if d.HasDuration() {
+//	    time.AfterFunc(d.Duration() + someFudgeDelta,
+//	                   func() { closed = s.Close(d) })
+//	  }
+//	}
 type State interface {
 	// Open returns a list of open signals
 	Open() []SegmentationDescriptor

--- a/scte35/segmentationdescriptor.go
+++ b/scte35/segmentationdescriptor.go
@@ -371,9 +371,7 @@ func (d *segmentationDescriptor) UPID() []byte {
 
 // StreamSwitchSignalId returns the signalID of streamswitch signal if
 // present in the descriptor
-func (d *segmentationDescriptor) StreamSwitchSignalId() (string, error) {
-	var signalId string
-	var err error
+func (d *segmentationDescriptor) StreamSwitchSignalId() (signalId string, licenseRotation bool, err error) {
 	// The VSS SignalId can be found either in the top level `segmentation_upid` when the UPID type is 0x09, or
 	// in the MID of len 2 when the first UPID has type 0x09 and the second UPID has type 0x0E.
 	if d.upidType == SegUPIDADI &&
@@ -387,10 +385,11 @@ func (d *segmentationDescriptor) StreamSwitchSignalId() (string, error) {
 		(d.mid[1].upidType == SegUPADSINFO) &&
 		(strings.Contains(string(d.mid[1].upid), "comcast:linear:licenserotation")) {
 		signalId = strings.TrimPrefix(string(d.mid[0].upid), "BLACKOUT:")
+		licenseRotation = true
 	} else {
 		err = gots.ErrVSSSignalIdNotFound
 	}
-	return signalId, err
+	return
 }
 
 // SegmentNum is deprecated, use SegmentNumber instead.

--- a/scte35/segmentationdescriptor_test.go
+++ b/scte35/segmentationdescriptor_test.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright 2016 Comcast Cable Communications Management, LLC
+# Copyright 2016 Comcast Cable Communications Management, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -268,7 +268,7 @@ func TestVSSSignalId(t *testing.T) {
 		t.FailNow()
 	}
 
-	signalID, err := vssScte35.Descriptors()[0].StreamSwitchSignalId()
+	signalID, licenseRotation, err := vssScte35.Descriptors()[0].StreamSwitchSignalId()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -277,6 +277,9 @@ func TestVSSSignalId(t *testing.T) {
 	if strings.Compare(signalID, expectedSignalId) != 0 {
 		t.Error("SignalID parsed, not as expected")
 		t.FailNow()
+	}
+	if !licenseRotation {
+		t.Error("License rotation should be true")
 	}
 }
 
@@ -289,7 +292,7 @@ func TestVSSSignalIdSingleUPID(t *testing.T) {
 		t.FailNow()
 	}
 
-	signalID, err := vssScte35.Descriptors()[0].StreamSwitchSignalId()
+	signalID, licenseRotation, err := vssScte35.Descriptors()[0].StreamSwitchSignalId()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -298,5 +301,8 @@ func TestVSSSignalIdSingleUPID(t *testing.T) {
 	if strings.Compare(signalID, expectedSignalId) != 0 {
 		t.Error("SignalID parsed, not as expected")
 		t.FailNow()
+	}
+	if licenseRotation {
+		t.Error("License rotation should be false")
 	}
 }

--- a/scte35/state.go
+++ b/scte35/state.go
@@ -25,8 +25,9 @@ SOFTWARE.
 package scte35
 
 import (
-	"github.com/Comcast/gots/v2"
 	"strings"
+
+	"github.com/Comcast/gots/v2"
 )
 
 const receivedRingLen = 10
@@ -85,19 +86,20 @@ func (s *state) ProcessDescriptor(desc SegmentationDescriptor) ([]SegmentationDe
 				// same eventId before.
 				if desc.EventID() == d.EventID() &&
 					d.TypeID() == SegDescUnscheduledEventStart && desc.TypeID() == SegDescUnscheduledEventStart {
-					descStreamSwitchSignalId, err := desc.StreamSwitchSignalId()
+					descStreamSwitchSignalId, descLicenseRotation, err := desc.StreamSwitchSignalId()
 					if err != nil {
 						return nil, err
 					}
 
-					dStreamSwitchSignalId, err := d.StreamSwitchSignalId()
+					dStreamSwitchSignalId, dLicenseRotation, err := d.StreamSwitchSignalId()
 					if err != nil {
 						return nil, err
 					}
 
 					if strings.Compare(descStreamSwitchSignalId, dStreamSwitchSignalId) == 0 &&
-						(d.EventID() == desc.EventID()) {
-						// desc and d contain same signalId and same eventID
+						(d.EventID() == desc.EventID()) &&
+						(descLicenseRotation == dLicenseRotation) {
+						// desc and d contain same signalId, same eventID, same license rotation UPID
 						// we should not be processing this desc.
 						return nil, gots.ErrSCTE35DuplicateDescriptor
 					}


### PR DESCRIPTION
Updates `StreamSwitchSignalId` to return a bool indicating whether a `licenserotation` UPID was found along with the returned signal id. 