### PR TITLE
Upgrade to `gots/v3`, Go 1.26

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.18.x, 1.19.x]
+        go-version: [1.24.x, 1.25.x, 1.26.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-[![Go Reference](https://pkg.go.dev/badge/github.com/Comcast/gots/v2.svg)](https://pkg.go.dev/github.com/Comcast/gots/v2)
+[![Go Reference](https://pkg.go.dev/badge/github.com/Comcast/gots/v3.svg)](https://pkg.go.dev/github.com/Comcast/gots/v3)
 [![Build Status](https://travis-ci.org/Comcast/gots.svg?branch=master)](https://travis-ci.org/Comcast/gots)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Comcast/gots)](https://goreportcard.com/report/github.com/Comcast/gots)
 [![Coverage Status](https://coveralls.io/repos/github/Comcast/gots/badge.svg?branch=master)](https://coveralls.io/github/Comcast/gots?branch=master)

--- a/cli/parsefile.go
+++ b/cli/parsefile.go
@@ -32,11 +32,11 @@ import (
 	"io"
 	"os"
 
-	"github.com/Comcast/gots/v2/ebp"
-	"github.com/Comcast/gots/v2/packet"
-	"github.com/Comcast/gots/v2/packet/adaptationfield"
-	"github.com/Comcast/gots/v2/psi"
-	"github.com/Comcast/gots/v2/scte35"
+	"github.com/Comcast/gots/v3/ebp"
+	"github.com/Comcast/gots/v3/packet"
+	"github.com/Comcast/gots/v3/packet/adaptationfield"
+	"github.com/Comcast/gots/v3/psi"
+	"github.com/Comcast/gots/v3/scte35"
 )
 
 // main parses a ts file that is provided with the -f flag

--- a/ebp/cablelabsebp.go
+++ b/ebp/cablelabsebp.go
@@ -29,7 +29,7 @@ import (
 	"encoding/binary"
 	"time"
 
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 // cableLabsEbp is an encoder boundary point

--- a/ebp/comcastebp.go
+++ b/ebp/comcastebp.go
@@ -29,7 +29,7 @@ import (
 	"encoding/binary"
 	"time"
 
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 // cableLabsEbp is an encoder boundary point

--- a/ebp/ebp.go
+++ b/ebp/ebp.go
@@ -28,7 +28,7 @@ import (
 	"encoding/binary"
 	"time"
 
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 // EBP tags

--- a/ebp/ebp_test.go
+++ b/ebp/ebp_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 var CableLabsEBPBytes = []byte{

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/Comcast/gots/v2
+module github.com/Comcast/gots/v3
 
-go 1.18
+go 1.26

--- a/packet/accumulator.go
+++ b/packet/accumulator.go
@@ -27,7 +27,7 @@ package packet
 import (
 	"bytes"
 
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 // Iotas to track the state of the accumulator

--- a/packet/accumulator_test.go
+++ b/packet/accumulator_test.go
@@ -28,7 +28,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 // PacketAccumulator is not thread safe

--- a/packet/adaptationfield.go
+++ b/packet/adaptationfield.go
@@ -25,7 +25,7 @@ SOFTWARE.
 package packet
 
 import (
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 const (

--- a/packet/adaptationfield/adaptationfield.go
+++ b/packet/adaptationfield/adaptationfield.go
@@ -1,8 +1,8 @@
 package adaptationfield
 
 import (
-	"github.com/Comcast/gots/v2"
-	"github.com/Comcast/gots/v2/packet"
+	"github.com/Comcast/gots/v3"
+	"github.com/Comcast/gots/v3/packet"
 )
 
 // Length returns the length of the adaptation field in bytes

--- a/packet/create.go
+++ b/packet/create.go
@@ -25,7 +25,7 @@ SOFTWARE.
 package packet
 
 import (
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 var (

--- a/packet/io.go
+++ b/packet/io.go
@@ -28,7 +28,7 @@ import (
 	"encoding/binary"
 	"io"
 
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 // Peeker wraps the Peek method.

--- a/packet/modify.go
+++ b/packet/modify.go
@@ -25,7 +25,7 @@ SOFTWARE.
 package packet
 
 import (
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 // flags that are reserved and should not be used.

--- a/packet/packet.go
+++ b/packet/packet.go
@@ -25,7 +25,7 @@ SOFTWARE.
 package packet
 
 import (
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 const (

--- a/packet/packetwriter.go
+++ b/packet/packetwriter.go
@@ -27,7 +27,7 @@ package packet
 import (
 	"io"
 
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 // PacketWriter is subject to all rules governing implementations of io.Writer

--- a/pes/pes.go
+++ b/pes/pes.go
@@ -24,7 +24,7 @@ SOFTWARE.
 
 package pes
 
-import "github.com/Comcast/gots/v2/packet"
+import "github.com/Comcast/gots/v3/packet"
 
 // AlignedPUSI checks for a PUSI with aligned flag set and returns a bool
 // indicating a match when true, as well as the bytes for the PES data

--- a/pes/pesheader.go
+++ b/pes/pesheader.go
@@ -28,7 +28,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 // stream_id possibilities

--- a/pes/pesheader_test.go
+++ b/pes/pesheader_test.go
@@ -27,7 +27,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/Comcast/gots/v2/packet"
+	"github.com/Comcast/gots/v3/packet"
 )
 
 func parseHexString(h string) *packet.Packet {

--- a/psi/pat.go
+++ b/psi/pat.go
@@ -28,8 +28,8 @@ import (
 	"errors"
 	"io"
 
-	"github.com/Comcast/gots/v2"
-	"github.com/Comcast/gots/v2/packet"
+	"github.com/Comcast/gots/v3"
+	"github.com/Comcast/gots/v3/packet"
 )
 
 const (

--- a/psi/pmt.go
+++ b/psi/pmt.go
@@ -30,8 +30,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/Comcast/gots/v2"
-	"github.com/Comcast/gots/v2/packet"
+	"github.com/Comcast/gots/v3"
+	"github.com/Comcast/gots/v3/packet"
 )
 
 const PidNotFound int = 1<<16 - 1

--- a/psi/pmt_test.go
+++ b/psi/pmt_test.go
@@ -30,8 +30,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Comcast/gots/v2"
-	"github.com/Comcast/gots/v2/packet"
+	"github.com/Comcast/gots/v3"
+	"github.com/Comcast/gots/v3/packet"
 )
 
 func parseHexString(h string) *packet.Packet {

--- a/psi/psi.go
+++ b/psi/psi.go
@@ -25,7 +25,7 @@ SOFTWARE.
 package psi
 
 import (
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 // TableHeader struct represents operations available on all PSI

--- a/scte35/descriptormodify.go
+++ b/scte35/descriptormodify.go
@@ -25,7 +25,7 @@ SOFTWARE.
 package scte35
 
 import (
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 // SetUPIDType will set the type of the UPID

--- a/scte35/doc.go
+++ b/scte35/doc.go
@@ -26,8 +26,8 @@ SOFTWARE.
 package scte35
 
 import (
-	"github.com/Comcast/gots/v2"
-	"github.com/Comcast/gots/v2/psi"
+	"github.com/Comcast/gots/v3"
+	"github.com/Comcast/gots/v3/psi"
 )
 
 // SpliceCommandType is a type used to describe the types of splice commands.

--- a/scte35/modify.go
+++ b/scte35/modify.go
@@ -25,8 +25,8 @@ SOFTWARE.
 package scte35
 
 import (
-	"github.com/Comcast/gots/v2"
-	"github.com/Comcast/gots/v2/psi"
+	"github.com/Comcast/gots/v3"
+	"github.com/Comcast/gots/v3/psi"
 )
 
 // CreateSCTE35 creates a default SCTE35 message and returns it.

--- a/scte35/modify_test.go
+++ b/scte35/modify_test.go
@@ -26,8 +26,8 @@ package scte35
 
 import (
 	"bytes"
-	"github.com/Comcast/gots/v2"
-	"github.com/Comcast/gots/v2/psi"
+	"github.com/Comcast/gots/v3"
+	"github.com/Comcast/gots/v3/psi"
 	"testing"
 )
 

--- a/scte35/scte35.go
+++ b/scte35/scte35.go
@@ -29,8 +29,8 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/Comcast/gots/v2"
-	"github.com/Comcast/gots/v2/psi"
+	"github.com/Comcast/gots/v3"
+	"github.com/Comcast/gots/v3/psi"
 )
 
 // Descriptor tag types and identifiers - only segmentation descriptors are used for now

--- a/scte35/scte35_test.go
+++ b/scte35/scte35_test.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 var testScte = []byte{

--- a/scte35/segmentationdescriptor.go
+++ b/scte35/segmentationdescriptor.go
@@ -29,7 +29,7 @@ import (
 	"encoding/binary"
 	"strings"
 
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 // upidSt is the struct used for creating a Multiple UPID (MID)

--- a/scte35/splicecommand.go
+++ b/scte35/splicecommand.go
@@ -28,7 +28,7 @@ import (
 	"bytes"
 	"encoding/binary"
 
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 // timeSignal is a struct that represents a time signal splice command in SCTE35

--- a/scte35/splicecommandmodify.go
+++ b/scte35/splicecommandmodify.go
@@ -25,7 +25,7 @@ SOFTWARE.
 package scte35
 
 import (
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 // CreateSpliceInsertCommand will create a default SpliceInsertCommand.

--- a/scte35/state.go
+++ b/scte35/state.go
@@ -27,7 +27,7 @@ package scte35
 import (
 	"strings"
 
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 const receivedRingLen = 10

--- a/scte35/state_test.go
+++ b/scte35/state_test.go
@@ -28,7 +28,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Comcast/gots/v2"
+	"github.com/Comcast/gots/v3"
 )
 
 // All signal data generated with scte_creator: https://github.comcast.com/mniebu200/scte_creator


### PR DESCRIPTION
Upgrade to `gots/v3` after #180 changed an interface/api (`StreamSwitchSignalId`)